### PR TITLE
fix: Fix `dbname` CLI Option Description

### DIFF
--- a/src/harlequin_postgres/cli_options.py
+++ b/src/harlequin_postgres/cli_options.py
@@ -34,8 +34,7 @@ port = TextOption(
 dbname = TextOption(
     name="dbname",
     description=(
-        "Port number to connect to at the server host, or socket file name extension "
-        "for Unix-domain connections."
+        "The database name to use when connecting with the Postgres server."
     ),
     short_decls=["-d"],
     default="postgres",


### PR DESCRIPTION
Updating description for `--dbanme` CLI option.
