### PR TITLE
fix: escape pg_ schema filter

### DIFF
--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -232,7 +232,7 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 where
                     catalog_name = %s
                     and schema_name != 'information_schema'
-                    and schema_name not like 'pg_%%'
+                    and schema_name not like 'pg\\_%%' escape '\\'
                 order by schema_name asc
                 ;""",
                 (dbname,),

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -84,6 +84,14 @@ def test_get_catalog(connection: HarlequinPostgresConnection) -> None:
     assert isinstance(catalog.items[0], CatalogItem)
 
 
+def test_get_schemas_includes_user_schema_named_pgmq(
+    connection: HarlequinPostgresConnection,
+) -> None:
+    connection.execute("create schema pgmq")
+    schemas = connection._get_schemas("test")
+    assert ("pgmq",) in schemas
+
+
 def test_get_completions(connection: HarlequinPostgresConnection) -> None:
     completions = connection.get_completions()
     test_labels = ["atomic", "greatest", "point_right", "autovacuum"]


### PR DESCRIPTION
 ## Summary

The Postgres adapter currently filters schemas with:

```sql
schema_name not like 'pg_%'
```

In SQL, _ is a single-character wildcard, so this also excludes user schemas like [pgmq](https://pgmq.github.io/pgmq/latest/), even though the intent is only to hide Postgres system schemas that literally start with pg_.

This change escapes the underscore so the filter only matches literal pg_ prefixes:
```
schema_name not like 'pg\_%' escape '\'
```

## Changes
- escape _ in the schema filter used by _get_schemas()
- add a regression test proving that a user schema named pgmq is included

## Why this matters

Without this fix, Harlequin’s Postgres catalog can hide legitimate user schemas whose names begin with pg, such as `pgmq`.