### PR TITLE
Allow multiple database connections in a single Harlequin session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Added handling for switching Postgres Databases on the fly without having to quit and reopen Harlequin with a different connection. ([#53](https://github.com/tconbeer/harlequin-postgres/issues/53))
+
 ## [1.3.1] - 2026-04-19
 
 - Fixes a bug causing user schemas starting with "pg" to be filtered out of the catalog. (#50)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
  
   db:
-    image: postgres
+    image: postgres:17
     restart: always
     environment:
       POSTGRES_PASSWORD: for-testing

--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -297,7 +297,7 @@ class HarlequinPostgresConnection(HarlequinConnection):
         return results
 
     def _get_schemas(self, dbname: str) -> list[tuple[str]]:
-        with self._borrow_conn(dbname) as conn, conn.cursor() as cur:
+        with self._borrow_conn() as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select schema_name
@@ -314,7 +314,7 @@ class HarlequinPostgresConnection(HarlequinConnection):
         return results
 
     def _get_relations(self, dbname: str, schema: str) -> list[tuple[str, str]]:
-        with self._borrow_conn(dbname) as conn, conn.cursor() as cur:
+        with self._borrow_conn() as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select table_name, table_type
@@ -347,7 +347,7 @@ class HarlequinPostgresConnection(HarlequinConnection):
     def _get_columns(
         self, dbname: str, schema: str, relation: str
     ) -> list[tuple[str, str]]:
-        with self._borrow_conn(dbname) as conn, conn.cursor() as cur:
+        with self._borrow_conn() as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select column_name, data_type
@@ -364,7 +364,7 @@ class HarlequinPostgresConnection(HarlequinConnection):
         return results
 
     def _get_mv_cols(self, dbname: str, schema: str, mv: str) -> list[tuple[str, str]]:
-        with self._borrow_conn(dbname) as conn, conn.cursor() as cur:
+        with self._borrow_conn() as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select 

--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from itertools import cycle
 from typing import Any, Sequence
 
@@ -93,15 +95,14 @@ class HarlequinPostgresConnection(HarlequinConnection):
                     "Invalid value for connection_timeout."
                 ),
             ) from e
+        self._conn_str = conn_str[0] if conn_str and conn_str[0] else ""
+        self._pool_options = options
+        self._pool_timeout = timeout
+        self._active_dbname = str(self.conn_info.get("dbname") or "postgres")
+        self._pools: dict[str, ConnectionPool] = {}
         try:
-            self.pool: ConnectionPool = ConnectionPool(
-                conninfo=conn_str[0] if conn_str and conn_str[0] else "",
-                min_size=2,
-                max_size=5,
-                kwargs=options,
-                open=True,
-                timeout=timeout,
-            )
+            self.pool = self._create_pool(self._active_dbname)
+            self._pools[self._active_dbname] = self.pool
             self._main_conn: Connection = self.pool.getconn()
         except Exception as e:
             raise HarlequinConnectionError(
@@ -119,6 +120,38 @@ class HarlequinPostgresConnection(HarlequinConnection):
             ]
         )
         self.toggle_transaction_mode()
+
+    def switch_database(self, dbname: str) -> None:
+        if dbname == self._active_dbname:
+            return
+        if (
+            self.transaction_mode.label != "Auto"
+            and self._main_conn.info.transaction_status != TransactionStatus.IDLE
+        ):
+            raise HarlequinConnectionError(
+                msg=(
+                    "Cannot switch databases while a manual transaction is active. "
+                    "Commit or rollback first."
+                ),
+                title="Harlequin could not switch Postgres databases.",
+            )
+
+        previous_pool = self.pool
+        previous_conn = self._main_conn
+        try:
+            pool = self._get_pool(dbname)
+            conn: Connection = pool.getconn()
+        except Exception as e:
+            raise HarlequinConnectionError(
+                msg=str(e),
+                title="Harlequin could not switch Postgres databases.",
+            ) from e
+
+        self.pool = pool
+        self._main_conn = conn
+        self._active_dbname = dbname
+        self._sync_transaction_mode()
+        previous_pool.putconn(previous_conn)
 
     def execute(self, query: str) -> HarlequinCursor | None:
         if (
@@ -176,14 +209,13 @@ class HarlequinPostgresConnection(HarlequinConnection):
         return Catalog(items=db_items)
 
     def get_completions(self) -> list[HarlequinCompletion]:
-        conn: Connection = self.pool.getconn()
-        completions = _get_completions(conn)
-        self.pool.putconn(conn)
-        return completions
+        with self._borrow_conn() as conn:
+            return _get_completions(conn)
 
     def close(self) -> None:
         self.pool.putconn(self._main_conn)
-        self.pool.close()
+        for pool in self._pools.values():
+            pool.close()
 
     @property
     def transaction_mode(self) -> HarlequinTransactionMode:
@@ -205,9 +237,34 @@ class HarlequinPostgresConnection(HarlequinConnection):
         else:
             conn.autocommit = False
 
+    def _create_pool(self, dbname: str) -> ConnectionPool:
+        return ConnectionPool(
+            conninfo=self._conn_str,
+            min_size=2,
+            max_size=5,
+            kwargs={**self._pool_options, "dbname": dbname},
+            open=True,
+            timeout=self._pool_timeout,
+        )
+
+    def _get_pool(self, dbname: str | None = None) -> ConnectionPool:
+        if dbname is None or dbname == self._active_dbname:
+            return self.pool
+        if dbname not in self._pools:
+            self._pools[dbname] = self._create_pool(dbname)
+        return self._pools[dbname]
+
+    @contextmanager
+    def _borrow_conn(self, dbname: str | None = None) -> Iterator[Connection]:
+        pool = self._get_pool(dbname)
+        conn: Connection = pool.getconn()
+        try:
+            yield conn
+        finally:
+            pool.putconn(conn)
+
     def _get_databases(self) -> list[tuple[str]]:
-        conn: Connection = self.pool.getconn()
-        with conn.cursor() as cur:
+        with self._borrow_conn() as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select datname
@@ -219,12 +276,10 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 ;"""
             )
             results: list[tuple[str]] = cur.fetchall()
-        self.pool.putconn(conn)
         return results
 
     def _get_schemas(self, dbname: str) -> list[tuple[str]]:
-        conn: Connection = self.pool.getconn()
-        with conn.cursor() as cur:
+        with self._borrow_conn(dbname) as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select schema_name
@@ -238,12 +293,10 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 (dbname,),
             )
             results: list[tuple[str]] = cur.fetchall()
-        self.pool.putconn(conn)
         return results
 
     def _get_relations(self, dbname: str, schema: str) -> list[tuple[str, str]]:
-        conn: Connection = self.pool.getconn()
-        with conn.cursor() as cur:
+        with self._borrow_conn(dbname) as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select table_name, table_type
@@ -256,13 +309,10 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 (dbname, schema),
             )
             results: list[tuple[str, str]] = cur.fetchall()
-        self.pool.putconn(conn)
         return results
 
-    # only works for the currently-connected db
-    def _get_mvs(self, schema: str) -> list[tuple[str]]:
-        conn: Connection = self.pool.getconn()
-        with conn.cursor() as cur:
+    def _get_mvs(self, dbname: str, schema: str) -> list[tuple[str]]:
+        with self._borrow_conn(dbname) as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select matviewname
@@ -274,14 +324,12 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 (schema,),
             )
             results: list[tuple[str]] = cur.fetchall()
-        self.pool.putconn(conn)
         return results
 
     def _get_columns(
         self, dbname: str, schema: str, relation: str
     ) -> list[tuple[str, str]]:
-        conn: Connection = self.pool.getconn()
-        with conn.cursor() as cur:
+        with self._borrow_conn(dbname) as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select column_name, data_type
@@ -295,12 +343,10 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 (dbname, schema, relation),
             )
             results: list[tuple[str, str]] = cur.fetchall()
-        self.pool.putconn(conn)
         return results
 
-    def _get_mv_cols(self, schema: str, mv: str) -> list[tuple[str, str]]:
-        conn: Connection = self.pool.getconn()
-        with conn.cursor() as cur:
+    def _get_mv_cols(self, dbname: str, schema: str, mv: str) -> list[tuple[str, str]]:
+        with self._borrow_conn(dbname) as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select 
@@ -319,7 +365,6 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 (schema, mv),
             )
             results: list[tuple[str, str]] = cur.fetchall()
-        self.pool.putconn(conn)
         return results
 
     @staticmethod

--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -14,7 +14,7 @@ from harlequin import (
 )
 from harlequin.catalog import Catalog, CatalogItem
 from harlequin.exception import HarlequinConnectionError, HarlequinQueryError
-from psycopg import Connection, Cursor, conninfo
+from psycopg import Connection, Cursor, connect, conninfo
 from psycopg.errors import QueryCanceled
 from psycopg.pq import TransactionStatus
 from psycopg_pool import ConnectionPool
@@ -101,15 +101,22 @@ class HarlequinPostgresConnection(HarlequinConnection):
         }
         self._pool_timeout = timeout
         self._pools: dict[str, ConnectionPool] = {}
+        pool: ConnectionPool | None = None
         try:
             initial_dbname = self.conn_info.get("dbname")
-            self.pool = self._create_pool(
+            pool = self._create_pool(
                 str(initial_dbname) if initial_dbname is not None else None
             )
+            self.pool = pool
             self._main_conn: Connection = self.pool.getconn()
             self._active_dbname = self._main_conn.info.dbname
             self._pools[self._active_dbname] = self.pool
         except Exception as e:
+            if pool is not None:
+                try:
+                    pool.close()
+                except Exception:
+                    pass
             raise HarlequinConnectionError(
                 msg=str(e), title="Harlequin could not connect to Postgres."
             ) from e
@@ -281,6 +288,22 @@ class HarlequinPostgresConnection(HarlequinConnection):
         finally:
             pool.putconn(conn)
 
+    @contextmanager
+    def _borrow_catalog_conn(self, dbname: str) -> Iterator[Connection]:
+        if dbname == self._active_dbname:
+            with self._borrow_conn() as conn:
+                yield conn
+            return
+
+        conn = connect(
+            conninfo=self._conn_str,
+            **{**self._pool_options, "dbname": dbname},
+        )
+        try:
+            yield conn
+        finally:
+            conn.close()
+
     def _get_databases(self) -> list[tuple[str]]:
         with self._borrow_conn() as conn, conn.cursor() as cur:
             cur.execute(
@@ -297,7 +320,7 @@ class HarlequinPostgresConnection(HarlequinConnection):
         return results
 
     def _get_schemas(self, dbname: str) -> list[tuple[str]]:
-        with self._borrow_conn() as conn, conn.cursor() as cur:
+        with self._borrow_catalog_conn(dbname) as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select schema_name
@@ -314,7 +337,7 @@ class HarlequinPostgresConnection(HarlequinConnection):
         return results
 
     def _get_relations(self, dbname: str, schema: str) -> list[tuple[str, str]]:
-        with self._borrow_conn() as conn, conn.cursor() as cur:
+        with self._borrow_catalog_conn(dbname) as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select table_name, table_type
@@ -330,7 +353,7 @@ class HarlequinPostgresConnection(HarlequinConnection):
         return results
 
     def _get_mvs(self, dbname: str, schema: str) -> list[tuple[str]]:
-        with self._borrow_conn(dbname) as conn, conn.cursor() as cur:
+        with self._borrow_catalog_conn(dbname) as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select matviewname
@@ -347,7 +370,7 @@ class HarlequinPostgresConnection(HarlequinConnection):
     def _get_columns(
         self, dbname: str, schema: str, relation: str
     ) -> list[tuple[str, str]]:
-        with self._borrow_conn() as conn, conn.cursor() as cur:
+        with self._borrow_catalog_conn(dbname) as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select column_name, data_type
@@ -364,7 +387,7 @@ class HarlequinPostgresConnection(HarlequinConnection):
         return results
 
     def _get_mv_cols(self, dbname: str, schema: str, mv: str) -> list[tuple[str, str]]:
-        with self._borrow_conn() as conn, conn.cursor() as cur:
+        with self._borrow_catalog_conn(dbname) as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select 

--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -96,14 +96,19 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 ),
             ) from e
         self._conn_str = conn_str[0] if conn_str and conn_str[0] else ""
-        self._pool_options = options
+        self._pool_options = {
+            key: value for key, value in options.items() if value is not None
+        }
         self._pool_timeout = timeout
-        self._active_dbname = str(self.conn_info.get("dbname") or "postgres")
         self._pools: dict[str, ConnectionPool] = {}
         try:
-            self.pool = self._create_pool(self._active_dbname)
-            self._pools[self._active_dbname] = self.pool
+            initial_dbname = self.conn_info.get("dbname")
+            self.pool = self._create_pool(
+                str(initial_dbname) if initial_dbname is not None else None
+            )
             self._main_conn: Connection = self.pool.getconn()
+            self._active_dbname = self._main_conn.info.dbname
+            self._pools[self._active_dbname] = self.pool
         except Exception as e:
             raise HarlequinConnectionError(
                 msg=str(e), title="Harlequin could not connect to Postgres."
@@ -138,10 +143,19 @@ class HarlequinPostgresConnection(HarlequinConnection):
 
         previous_pool = self.pool
         previous_conn = self._main_conn
+        conn: Connection | None = None
+        pool: ConnectionPool | None = None
         try:
             pool = self._get_pool(dbname)
-            conn: Connection = pool.getconn()
+            conn = pool.getconn()
+            self._sync_transaction_mode(conn)
+            previous_pool.putconn(previous_conn)
         except Exception as e:
+            if pool is not None and conn is not None:
+                try:
+                    pool.putconn(conn)
+                except Exception:
+                    pass
             raise HarlequinConnectionError(
                 msg=str(e),
                 title="Harlequin could not switch Postgres databases.",
@@ -150,8 +164,6 @@ class HarlequinPostgresConnection(HarlequinConnection):
         self.pool = pool
         self._main_conn = conn
         self._active_dbname = dbname
-        self._sync_transaction_mode()
-        previous_pool.putconn(previous_conn)
 
     def execute(self, query: str) -> HarlequinCursor | None:
         if (
@@ -226,23 +238,29 @@ class HarlequinPostgresConnection(HarlequinConnection):
         self._sync_transaction_mode()
         return self._transaction_mode
 
-    def _sync_transaction_mode(self) -> None:
+    def _sync_transaction_mode(self, conn: Connection | None = None) -> None:
         """
-        Sync this class's transaction mode with the main connection
+        Sync this class's transaction mode with a connection.
         """
-        conn = self._main_conn
+        if conn is None:
+            conn = self._main_conn
         if self.transaction_mode.label == "Auto":
             conn.autocommit = True
             conn.commit()
         else:
             conn.autocommit = False
 
-    def _create_pool(self, dbname: str) -> ConnectionPool:
+    def _create_pool(self, dbname: str | None) -> ConnectionPool:
+        kwargs = (
+            self._pool_options
+            if dbname is None
+            else {**self._pool_options, "dbname": dbname}
+        )
         return ConnectionPool(
             conninfo=self._conn_str,
             min_size=2,
             max_size=5,
-            kwargs={**self._pool_options, "dbname": dbname},
+            kwargs=kwargs,
             open=True,
             timeout=self._pool_timeout,
         )

--- a/src/harlequin_postgres/catalog.py
+++ b/src/harlequin_postgres/catalog.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from harlequin.catalog import InteractiveCatalogItem
 
 from harlequin_postgres.interactions import (
+    execute_connect_database_statement,
     execute_drop_database_statement,
     execute_drop_foreign_table_statement,
     execute_drop_schema_statement,
@@ -187,7 +188,9 @@ class MaterializedViewCatalogItem(RelationCatalogItem):
     def fetch_children(self) -> list[ColumnCatalogItem]:
         if self.parent is None or self.parent.parent is None or self.connection is None:
             return []
-        result = self.connection._get_mv_cols(self.parent.label, self.label)
+        result = self.connection._get_mv_cols(
+            self.parent.parent.label, self.parent.label, self.label
+        )
         return [
             ColumnCatalogItem.from_parent(
                 parent=self,
@@ -259,7 +262,7 @@ class SchemaCatalogItem(InteractiveCatalogItem["HarlequinPostgresConnection"]):
                     )
                 )
 
-        for (mv_label,) in self.connection._get_mvs(self.label):
+        for (mv_label,) in self.connection._get_mvs(self.parent.label, self.label):
             children.append(
                 MaterializedViewCatalogItem.from_parent(
                     parent=self,
@@ -272,6 +275,7 @@ class SchemaCatalogItem(InteractiveCatalogItem["HarlequinPostgresConnection"]):
 
 class DatabaseCatalogItem(InteractiveCatalogItem["HarlequinPostgresConnection"]):
     INTERACTIONS = [
+        ("Connect to Database", execute_connect_database_statement),
         ("List Relations (\\d+)", show_list_objects),
         ("List Indexes (\\di+)", show_list_indexes),
         ("Drop Database", execute_drop_database_statement),

--- a/src/harlequin_postgres/interactions.py
+++ b/src/harlequin_postgres/interactions.py
@@ -77,6 +77,24 @@ def execute_drop_database_statement(
         _drop_database()
 
 
+def execute_connect_database_statement(
+    item: "DatabaseCatalogItem",
+    driver: "HarlequinDriver",
+) -> None:
+    if item.connection is None:
+        return
+    try:
+        item.connection.switch_database(item.label)
+    except HarlequinQueryError:
+        driver.notify(f"Could not connect to database {item.label}", severity="error")
+        raise
+    except Exception:
+        driver.notify(f"Could not connect to database {item.label}", severity="error")
+        raise
+    else:
+        driver.notify(f"Connected to database {item.label}")
+
+
 def execute_drop_relation_statement(
     item: "RelationCatalogItem",
     driver: "HarlequinDriver",

--- a/src/harlequin_postgres/interactions.py
+++ b/src/harlequin_postgres/interactions.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 from typing import TYPE_CHECKING, Literal, Sequence
 
 from harlequin.catalog import CatalogItem
-from harlequin.exception import HarlequinQueryError
+from harlequin.exception import HarlequinConnectionError, HarlequinQueryError
 
 if TYPE_CHECKING:
     from harlequin.driver import HarlequinDriver

--- a/src/harlequin_postgres/interactions.py
+++ b/src/harlequin_postgres/interactions.py
@@ -85,10 +85,7 @@ def execute_connect_database_statement(
         return
     try:
         item.connection.switch_database(item.label)
-    except HarlequinQueryError:
-        driver.notify(f"Could not connect to database {item.label}", severity="error")
-        raise
-    except Exception:
+    except HarlequinConnectionError:
         driver.notify(f"Could not connect to database {item.label}", severity="error")
         raise
     else:

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -93,6 +93,7 @@ class FakeConnection:
 
 class FakePool:
     pools: list["FakePool"] = []
+    direct_connections: list[FakeConnection] = []
     fail_databases: set[str] = set()
     fail_getconn_databases: set[str] = set()
     fail_putconn_databases: set[str] = set()
@@ -133,10 +134,21 @@ class FakePool:
 @pytest.fixture
 def fake_pools(monkeypatch: pytest.MonkeyPatch) -> type[FakePool]:
     FakePool.pools = []
+    FakePool.direct_connections = []
     FakePool.fail_databases = set()
     FakePool.fail_getconn_databases = set()
     FakePool.fail_putconn_databases = set()
     monkeypatch.setattr(postgres_adapter, "ConnectionPool", FakePool)
+
+    def fake_connect(
+        conninfo: str,
+        **kwargs: object,
+    ) -> FakeConnection:
+        conn = FakeConnection(str(kwargs.get("dbname") or "env_db"))
+        FakePool.direct_connections.append(conn)
+        return conn
+
+    monkeypatch.setattr(postgres_adapter, "connect", fake_connect, raising=False)
     return FakePool
 
 
@@ -165,13 +177,20 @@ def test_plugin_discovery() -> None:
 
 def test_connect() -> None:
     conn = HarlequinPostgresAdapter(conn_str=(TEST_DB_CONN,)).connect()
-    assert isinstance(conn, HarlequinConnection)
+    try:
+        assert isinstance(conn, HarlequinConnection)
+    finally:
+        conn.close()
 
 
 def test_init_extra_kwargs() -> None:
-    assert HarlequinPostgresAdapter(
+    conn = HarlequinPostgresAdapter(
         conn_str=(TEST_DB_CONN,), foo=1, bar="baz"
     ).connect()
+    try:
+        assert conn
+    finally:
+        conn.close()
 
 
 @pytest.mark.parametrize(
@@ -317,7 +336,18 @@ def test_initial_connection_does_not_force_postgres_when_dbname_not_explicit(
     assert connection._active_dbname == "env_db"
 
 
-def test_get_schemas_borrows_connection_for_requested_database(
+def test_init_closes_pool_when_initial_checkout_fails(
+    fake_pools: type[FakePool],
+) -> None:
+    fake_pools.fail_getconn_databases.add("postgres")
+
+    with pytest.raises(HarlequinConnectionError):
+        make_connection()
+
+    assert fake_pools.pools[0].closed is True
+
+
+def test_get_schemas_uses_uncached_connection_for_requested_database(
     fake_pools: type[FakePool],
 ) -> None:
     connection = make_connection()
@@ -326,10 +356,61 @@ def test_get_schemas_borrows_connection_for_requested_database(
 
     assert schemas == [("public",)]
     assert cast(FakeConnection, connection._main_conn).dbname == "postgres"
-    analytics_pool = fake_pools.pools[-1]
-    assert analytics_pool.dbname == "analytics"
-    assert analytics_pool.getconn_calls == 1
-    assert analytics_pool.putconn_calls == [analytics_pool.connection]
+    assert [conn.dbname for conn in fake_pools.direct_connections] == ["analytics"]
+    assert fake_pools.direct_connections[-1].closed is True
+    assert set(connection._pools) == {"postgres"}
+
+
+def test_get_relations_uses_uncached_connection_for_requested_database(
+    fake_pools: type[FakePool],
+) -> None:
+    connection = make_connection()
+
+    connection._get_relations("analytics", "public")
+
+    assert cast(FakeConnection, connection._main_conn).dbname == "postgres"
+    assert [conn.dbname for conn in fake_pools.direct_connections] == ["analytics"]
+    assert fake_pools.direct_connections[-1].closed is True
+    assert set(connection._pools) == {"postgres"}
+
+
+def test_get_mvs_uses_uncached_connection_for_requested_database(
+    fake_pools: type[FakePool],
+) -> None:
+    connection = make_connection()
+
+    connection._get_mvs("analytics", "public")
+
+    assert cast(FakeConnection, connection._main_conn).dbname == "postgres"
+    assert [conn.dbname for conn in fake_pools.direct_connections] == ["analytics"]
+    assert fake_pools.direct_connections[-1].closed is True
+    assert set(connection._pools) == {"postgres"}
+
+
+def test_get_columns_uses_uncached_connection_for_requested_database(
+    fake_pools: type[FakePool],
+) -> None:
+    connection = make_connection()
+
+    connection._get_columns("analytics", "public", "events")
+
+    assert cast(FakeConnection, connection._main_conn).dbname == "postgres"
+    assert [conn.dbname for conn in fake_pools.direct_connections] == ["analytics"]
+    assert fake_pools.direct_connections[-1].closed is True
+    assert set(connection._pools) == {"postgres"}
+
+
+def test_get_mv_cols_uses_uncached_connection_for_requested_database(
+    fake_pools: type[FakePool],
+) -> None:
+    connection = make_connection()
+
+    connection._get_mv_cols("analytics", "public", "event_rollups")
+
+    assert cast(FakeConnection, connection._main_conn).dbname == "postgres"
+    assert [conn.dbname for conn in fake_pools.direct_connections] == ["analytics"]
+    assert fake_pools.direct_connections[-1].closed is True
+    assert set(connection._pools) == {"postgres"}
 
 
 def test_get_catalog(connection: HarlequinPostgresConnection) -> None:

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from datetime import date, datetime
+from typing import cast
 
 import pytest
 from harlequin.adapter import HarlequinAdapter, HarlequinConnection, HarlequinCursor
@@ -9,6 +10,7 @@ from harlequin.catalog import Catalog, CatalogItem
 from harlequin.exception import HarlequinConnectionError, HarlequinQueryError
 from textual_fastdatatable.backend import create_backend
 
+import harlequin_postgres.adapter as postgres_adapter
 from harlequin_postgres.adapter import (
     HarlequinPostgresAdapter,
     HarlequinPostgresConnection,
@@ -20,6 +22,111 @@ else:
     from importlib.metadata import entry_points
 
 TEST_DB_CONN = "postgresql://postgres:for-testing@localhost:5432"
+
+
+class FakeInfo:
+    transaction_status = 0
+
+
+class FakeCursor:
+    description = None
+
+    def __init__(self, result: list[tuple[str]] | None = None) -> None:
+        self.result = result or []
+        self.queries: list[tuple[str, tuple[str, ...] | None]] = []
+
+    def __enter__(self) -> "FakeCursor":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        return None
+
+    def execute(
+        self,
+        query: str,
+        params: tuple[str, ...] | None = None,
+    ) -> None:
+        self.queries.append((query, params))
+
+    def fetchall(self) -> list[tuple[str]]:
+        return self.result
+
+    def close(self) -> None:
+        return None
+
+
+class FakeConnection:
+    def __init__(self, dbname: str) -> None:
+        self.dbname = dbname
+        self.autocommit = False
+        self.info = FakeInfo()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.cursor_calls = 0
+        self.last_cursor: FakeCursor | None = None
+
+    def cursor(self) -> FakeCursor:
+        self.cursor_calls += 1
+        self.last_cursor = FakeCursor(result=[("public",)])
+        return self.last_cursor
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakePool:
+    pools: list["FakePool"] = []
+    fail_databases: set[str] = set()
+
+    def __init__(
+        self,
+        conninfo: str,
+        *_: object,
+        kwargs: dict[str, object | None] | None = None,
+        **__: object,
+    ) -> None:
+        self.conninfo = conninfo
+        self.kwargs = kwargs or {}
+        self.dbname = str(self.kwargs.get("dbname") or "postgres")
+        if self.dbname in self.fail_databases:
+            raise RuntimeError(f"cannot connect to {self.dbname}")
+        self.connection = FakeConnection(self.dbname)
+        self.getconn_calls = 0
+        self.putconn_calls: list[FakeConnection] = []
+        self.closed = False
+        self.pools.append(self)
+
+    def getconn(self) -> FakeConnection:
+        self.getconn_calls += 1
+        return self.connection
+
+    def putconn(self, conn: FakeConnection) -> None:
+        self.putconn_calls.append(conn)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def fake_pools(monkeypatch: pytest.MonkeyPatch) -> type[FakePool]:
+    FakePool.pools = []
+    FakePool.fail_databases = set()
+    monkeypatch.setattr(postgres_adapter, "ConnectionPool", FakePool)
+    return FakePool
+
+
+def make_connection() -> HarlequinPostgresConnection:
+    return HarlequinPostgresConnection(
+        ("postgresql://postgres:for-testing@localhost:5432/postgres",),
+        options={},
+    )
 
 
 def test_plugin_discovery() -> None:
@@ -75,6 +182,50 @@ def test_connection_id(
         **options,  # type: ignore[arg-type]
     )
     assert adapter.connection_id == expected
+
+
+def test_switch_database_changes_active_connection_and_reuses_pool(
+    fake_pools: type[FakePool],
+) -> None:
+    connection = make_connection()
+
+    connection.switch_database("analytics")
+    analytics_pool = fake_pools.pools[-1]
+    connection.switch_database("postgres")
+    connection.switch_database("analytics")
+
+    assert cast(FakeConnection, connection._main_conn).dbname == "analytics"
+    assert fake_pools.pools == [fake_pools.pools[0], analytics_pool]
+    assert analytics_pool.getconn_calls == 2
+
+
+def test_switch_database_preserves_active_connection_when_target_fails(
+    fake_pools: type[FakePool],
+) -> None:
+    connection = make_connection()
+    original_conn = connection._main_conn
+    fake_pools.fail_databases.add("missing")
+
+    with pytest.raises(HarlequinConnectionError):
+        connection.switch_database("missing")
+
+    assert connection._main_conn is original_conn
+    assert cast(FakeConnection, connection._main_conn).dbname == "postgres"
+
+
+def test_get_schemas_borrows_connection_for_requested_database(
+    fake_pools: type[FakePool],
+) -> None:
+    connection = make_connection()
+
+    schemas = connection._get_schemas("analytics")
+
+    assert schemas == [("public",)]
+    assert cast(FakeConnection, connection._main_conn).dbname == "postgres"
+    analytics_pool = fake_pools.pools[-1]
+    assert analytics_pool.dbname == "analytics"
+    assert analytics_pool.getconn_calls == 1
+    assert analytics_pool.putconn_calls == [analytics_pool.connection]
 
 
 def test_get_catalog(connection: HarlequinPostgresConnection) -> None:

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -8,6 +8,7 @@ import pytest
 from harlequin.adapter import HarlequinAdapter, HarlequinConnection, HarlequinCursor
 from harlequin.catalog import Catalog, CatalogItem
 from harlequin.exception import HarlequinConnectionError, HarlequinQueryError
+from psycopg.pq import TransactionStatus
 from textual_fastdatatable.backend import create_backend
 
 import harlequin_postgres.adapter as postgres_adapter
@@ -25,7 +26,13 @@ TEST_DB_CONN = "postgresql://postgres:for-testing@localhost:5432"
 
 
 class FakeInfo:
-    transaction_status = 0
+    def __init__(
+        self,
+        dbname: str,
+        transaction_status: TransactionStatus = TransactionStatus.IDLE,
+    ) -> None:
+        self.dbname = dbname
+        self.transaction_status = transaction_status
 
 
 class FakeCursor:
@@ -59,12 +66,13 @@ class FakeConnection:
     def __init__(self, dbname: str) -> None:
         self.dbname = dbname
         self.autocommit = False
-        self.info = FakeInfo()
+        self.info = FakeInfo(dbname)
         self.commits = 0
         self.rollbacks = 0
         self.closed = False
         self.cursor_calls = 0
         self.last_cursor: FakeCursor | None = None
+        self.fail_commit = False
 
     def cursor(self) -> FakeCursor:
         self.cursor_calls += 1
@@ -72,6 +80,8 @@ class FakeConnection:
         return self.last_cursor
 
     def commit(self) -> None:
+        if self.fail_commit:
+            raise RuntimeError(f"cannot sync transaction mode for {self.dbname}")
         self.commits += 1
 
     def rollback(self) -> None:
@@ -84,6 +94,8 @@ class FakeConnection:
 class FakePool:
     pools: list["FakePool"] = []
     fail_databases: set[str] = set()
+    fail_getconn_databases: set[str] = set()
+    fail_putconn_databases: set[str] = set()
 
     def __init__(
         self,
@@ -94,7 +106,7 @@ class FakePool:
     ) -> None:
         self.conninfo = conninfo
         self.kwargs = kwargs or {}
-        self.dbname = str(self.kwargs.get("dbname") or "postgres")
+        self.dbname = str(self.kwargs.get("dbname") or "env_db")
         if self.dbname in self.fail_databases:
             raise RuntimeError(f"cannot connect to {self.dbname}")
         self.connection = FakeConnection(self.dbname)
@@ -104,10 +116,14 @@ class FakePool:
         self.pools.append(self)
 
     def getconn(self) -> FakeConnection:
+        if self.dbname in self.fail_getconn_databases:
+            raise RuntimeError(f"cannot borrow connection to {self.dbname}")
         self.getconn_calls += 1
         return self.connection
 
     def putconn(self, conn: FakeConnection) -> None:
+        if self.dbname in self.fail_putconn_databases:
+            raise RuntimeError(f"cannot return connection to {self.dbname}")
         self.putconn_calls.append(conn)
 
     def close(self) -> None:
@@ -118,6 +134,8 @@ class FakePool:
 def fake_pools(monkeypatch: pytest.MonkeyPatch) -> type[FakePool]:
     FakePool.pools = []
     FakePool.fail_databases = set()
+    FakePool.fail_getconn_databases = set()
+    FakePool.fail_putconn_databases = set()
     monkeypatch.setattr(postgres_adapter, "ConnectionPool", FakePool)
     return FakePool
 
@@ -125,6 +143,13 @@ def fake_pools(monkeypatch: pytest.MonkeyPatch) -> type[FakePool]:
 def make_connection() -> HarlequinPostgresConnection:
     return HarlequinPostgresConnection(
         ("postgresql://postgres:for-testing@localhost:5432/postgres",),
+        options={},
+    )
+
+
+def make_env_connection() -> HarlequinPostgresConnection:
+    return HarlequinPostgresConnection(
+        ("postgresql://postgres:for-testing@localhost:5432",),
         options={},
     )
 
@@ -211,6 +236,85 @@ def test_switch_database_preserves_active_connection_when_target_fails(
 
     assert connection._main_conn is original_conn
     assert cast(FakeConnection, connection._main_conn).dbname == "postgres"
+
+
+def test_switch_database_preserves_active_connection_when_target_checkout_fails(
+    fake_pools: type[FakePool],
+) -> None:
+    connection = make_connection()
+    original_conn = connection._main_conn
+    fake_pools.fail_getconn_databases.add("analytics")
+
+    with pytest.raises(HarlequinConnectionError):
+        connection.switch_database("analytics")
+
+    assert cast(FakePool, connection.pool) is fake_pools.pools[0]
+    assert connection._main_conn is original_conn
+    assert connection._active_dbname == "postgres"
+
+
+def test_switch_database_preserves_active_connection_when_sync_fails(
+    fake_pools: type[FakePool],
+) -> None:
+    connection = make_connection()
+    original_pool = cast(FakePool, connection.pool)
+    original_conn = connection._main_conn
+    connection.switch_database("analytics")
+    analytics_pool = cast(FakePool, connection.pool)
+    analytics_conn = cast(FakeConnection, connection._main_conn)
+    analytics_conn.fail_commit = True
+    connection.switch_database("postgres")
+
+    with pytest.raises(HarlequinConnectionError):
+        connection.switch_database("analytics")
+
+    assert cast(FakePool, connection.pool) is original_pool
+    assert connection._main_conn is original_conn
+    assert connection._active_dbname == "postgres"
+    assert analytics_pool.putconn_calls[-1] is analytics_conn
+
+
+def test_switch_database_preserves_active_connection_when_returning_previous_fails(
+    fake_pools: type[FakePool],
+) -> None:
+    connection = make_connection()
+    original_pool = cast(FakePool, connection.pool)
+    original_conn = connection._main_conn
+    fake_pools.fail_putconn_databases.add("postgres")
+
+    with pytest.raises(HarlequinConnectionError):
+        connection.switch_database("analytics")
+
+    analytics_pool = fake_pools.pools[-1]
+    assert cast(FakePool, connection.pool) is original_pool
+    assert connection._main_conn is original_conn
+    assert connection._active_dbname == "postgres"
+    assert analytics_pool.putconn_calls == [analytics_pool.connection]
+
+
+def test_switch_database_rejects_active_manual_transaction(
+    fake_pools: type[FakePool],
+) -> None:
+    connection = make_connection()
+    connection.toggle_transaction_mode()
+    cast(
+        FakeConnection, connection._main_conn
+    ).info.transaction_status = TransactionStatus.INTRANS
+
+    with pytest.raises(HarlequinConnectionError):
+        connection.switch_database("analytics")
+
+    assert len(fake_pools.pools) == 1
+    assert cast(FakeConnection, connection._main_conn).dbname == "postgres"
+
+
+def test_initial_connection_does_not_force_postgres_when_dbname_not_explicit(
+    fake_pools: type[FakePool],
+) -> None:
+    connection = make_env_connection()
+
+    assert fake_pools.pools[0].kwargs == {}
+    assert connection._active_dbname == "env_db"
 
 
 def test_get_schemas_borrows_connection_for_requested_database(

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -11,6 +11,23 @@ from harlequin_postgres.catalog import (
     TableCatalogItem,
     ViewCatalogItem,
 )
+from harlequin_postgres.interactions import execute_connect_database_statement
+
+
+class FakeDriver:
+    def __init__(self) -> None:
+        self.notifications: list[tuple[str, str | None]] = []
+
+    def notify(self, message: str, severity: str | None = None) -> None:
+        self.notifications.append((message, severity))
+
+
+class FakeSwitchConnection:
+    def __init__(self) -> None:
+        self.switched_to: list[str] = []
+
+    def switch_database(self, dbname: str) -> None:
+        self.switched_to.append(dbname)
 
 
 @pytest.fixture
@@ -111,3 +128,21 @@ def test_catalog(connection_with_objects: HarlequinPostgresConnection) -> None:
     foo_mv_cols = foo_mv_item.fetch_children()
     assert foo_mv_cols
     assert all(isinstance(item, ColumnCatalogItem) for item in foo_mv_cols)
+
+
+def test_database_catalog_item_can_switch_active_database() -> None:
+    connection = FakeSwitchConnection()
+    driver = FakeDriver()
+    item = DatabaseCatalogItem.from_label(
+        label="analytics",
+        connection=connection,  # type: ignore[arg-type]
+    )
+
+    execute_connect_database_statement(item, driver)  # type: ignore[arg-type]
+
+    assert DatabaseCatalogItem.INTERACTIONS[0] == (
+        "Connect to Database",
+        execute_connect_database_statement,
+    )
+    assert connection.switched_to == ["analytics"]
+    assert driver.notifications == [("Connected to database analytics", None)]


### PR DESCRIPTION
 ## Summary

  Resolves #53.

  This PR adds multi-database support to the Postgres adapter so a Harlequin session can browse and switch between databases on the same Postgres server.

  The main change is that the adapter now keeps a lazy cache of connection pools by database. PostgreSQL connections are database-scoped, so catalog queries for another database need a real connection to
  that database rather than reusing the currently active connection. Creating pools lazily lets us avoid connecting to every database up front while still reusing pools after a database has been visited.

  ## Changes

  - Added database switching through a new `Connect to Database` catalog interaction.
  - Added one connection pool per visited database, with the active query connection swapped when switching databases.
  - Updated catalog loading so schemas, relations, columns, and materialized views are fetched from the database being inspected.
  - Preserved libpq/environment/default database behavior when no database name is explicitly provided.
  - Closed all cached pools when the adapter connection is closed.
  - Pinned the local Docker Postgres image to `postgres:17`.

  ## Edge Cases Covered

  Tests were added for:

  - Reusing an existing pool when switching back to a previously visited database.
  - Preserving the current active connection when target pool creation fails.
  - Preserving the current active connection when target connection checkout fails.
  - Returning a borrowed target connection if transaction-mode sync fails.
  - Avoiding a half-switched state if returning the previous connection fails.
  - Rejecting database switches while a manual transaction is active.
  - Respecting default/environment-selected databases instead of forcing `postgres`.
  - Verifying catalog schema lookups borrow from the requested database without changing the active database.
  - Verifying the new catalog interaction calls `switch_database` and notifies the user.
