### PR TITLE
feat: expose foreign_key_columns() on the cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Adds `HarlequinPostgresCursor.foreign_key_columns()`, which reports the referenced table and column for result columns that are single-column foreign keys (used by Harlequin's foreign-key navigation, tconbeer/harlequin#986). Works across joins, since each result column carries its own source table.
+
 ## [1.4.0] - 2026-08-29
 
 - This adapter now supports Harlequin's `--read-only` option and declares `IMPLEMENTS_READ_ONLY`. Read-only connections are enforced by the server, using `set session characteristics as transaction read only` ([#58](https://github.com/tconbeer/harlequin-postgres/issues/58)).

--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -181,6 +181,55 @@ class HarlequinPostgresCursor(HarlequinCursor):
         assert cur.description is not None
         self.description = cur.description.copy()
         self._limit: int | None = None
+        # Capture each result column's source table OID and column number (attnum)
+        # from the libpq result while the cursor is still open. A table OID of 0
+        # means the column is computed/derived (not a plain table column), so it
+        # can't be a foreign key. This drives the FK-navigation feature.
+        self._column_sources: list[tuple[int, int]] = []
+        try:
+            pgresult = cur.pgresult
+            if pgresult is not None:
+                self._column_sources = [
+                    (pgresult.ftable(i), pgresult.ftablecol(i))
+                    for i in range(pgresult.nfields)
+                ]
+        except Exception:
+            self._column_sources = []
+
+    def foreign_key_columns(self) -> dict[int, tuple[str, str]]:
+        """Map result-column index -> (referenced_qualified_table, referenced_column)
+        for result columns that are single-column foreign keys. Works across joins,
+        since each column carries its own source table. Returns {} if none."""
+        source_oids = sorted({oid for oid, _ in self._column_sources if oid})
+        if not source_oids:
+            return {}
+        query = """
+            select con.conrelid as toid, con.conkey[1] as attnum,
+                   fn.nspname as ref_schema, fc.relname as ref_table,
+                   fa.attname as ref_col
+            from pg_constraint con
+            join pg_class fc on con.confrelid = fc.oid
+            join pg_namespace fn on fc.relnamespace = fn.oid
+            join pg_attribute fa on fa.attrelid = con.confrelid
+                and fa.attnum = con.confkey[1]
+            where con.contype = 'f'
+                and array_length(con.conkey, 1) = 1
+                and con.conrelid = any(%s)
+        """
+        try:
+            with self.conn.pool.connection() as c:
+                rows = c.execute(query, (source_oids,)).fetchall()
+        except Exception:
+            return {}
+        ref_by_source = {
+            (toid, attnum): (f'"{ref_schema}"."{ref_table}"', f'"{ref_col}"')
+            for (toid, attnum, ref_schema, ref_table, ref_col) in rows
+        }
+        return {
+            idx: ref_by_source[(oid, attnum)]
+            for idx, (oid, attnum) in enumerate(self._column_sources)
+            if (oid, attnum) in ref_by_source
+        }
 
     def columns(self) -> list[tuple[str, str]]:
         return [

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -13,6 +13,7 @@ from textual_fastdatatable.backend import create_backend
 from harlequin_postgres.adapter import (
     HarlequinPostgresAdapter,
     HarlequinPostgresConnection,
+    HarlequinPostgresCursor,
 )
 
 if sys.version_info < (3, 10):
@@ -294,3 +295,55 @@ def test_read_only_enforced_in_autocommit_session(
     assert read_only_connection._main_conn.autocommit is True
     with pytest.raises(HarlequinQueryError):
         read_only_connection.execute("insert into foo values (2)")
+
+
+def test_foreign_key_columns(
+    connection: HarlequinPostgresConnection,
+) -> None:
+    connection.execute("create table fk_parent (id int primary key)")
+    connection.execute(
+        "create table fk_child "
+        "(id int primary key, parent_id int references fk_parent(id))"
+    )
+
+    cur = connection.execute("select id, parent_id from fk_child")
+    assert isinstance(cur, HarlequinPostgresCursor)
+    fk = cur.foreign_key_columns()
+
+    # result column 1 (parent_id) is a foreign key -> fk_parent.id
+    assert 1 in fk
+    ref_table, ref_col = fk[1]
+    assert "fk_parent" in ref_table
+    assert "id" in ref_col
+    # the primary key column is not itself a foreign key
+    assert 0 not in fk
+
+
+def test_foreign_key_columns_across_a_join(
+    connection: HarlequinPostgresConnection,
+) -> None:
+    connection.execute("create table fk_parent (id int primary key)")
+    connection.execute(
+        "create table fk_child "
+        "(id int primary key, parent_id int references fk_parent(id))"
+    )
+
+    # each result column carries its own source table, so an FK is detected
+    # even when the result comes from a join.
+    cur = connection.execute(
+        "select c.parent_id from fk_child c join fk_parent p on c.parent_id = p.id"
+    )
+    assert isinstance(cur, HarlequinPostgresCursor)
+    fk = cur.foreign_key_columns()
+    assert 0 in fk
+    ref_table, _ = fk[0]
+    assert "fk_parent" in ref_table
+
+
+def test_no_foreign_keys_returns_empty(
+    connection: HarlequinPostgresConnection,
+) -> None:
+    connection.execute("create table plain (a int, b text)")
+    cur = connection.execute("select a, b from plain")
+    assert isinstance(cur, HarlequinPostgresCursor)
+    assert cur.foreign_key_columns() == {}


### PR DESCRIPTION
Adds `HarlequinPostgresCursor.foreign_key_columns()`: result-column index → `(referenced_qualified_table, referenced_column)` for result columns that are single-column foreign keys. It is driven by the source-table metadata libpq attaches to every result column (`ftable`/`ftablecol`), captured while the cursor is open, so it works across joins. Returns `{}` when there are none, and swallows metadata-query failures so it can never break fetching.

Harlequin's foreign-key navigation (tconbeer/harlequin#986) asks for it.

Rebased onto 1.4.0. `editable_columns()`, which used to be the last commit here, moved to its own PR (#64) so the two can land independently; both add the same source-column capture to the cursor's `__init__`.

### Tests
`test_foreign_key_columns`, `test_foreign_key_columns_across_a_join`, `test_no_foreign_keys_returns_empty`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
