### PR TITLE
perf: fetch all of a schema's columns in one query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fetches all of a schema's columns in a single query when the schema's children are loaded, instead of one query per table/view. This makes browsing the Data Catalog much faster over high-latency connections. Materialized views keep their per-item lazy load.
+
 ## [1.4.0] - 2026-08-29
 
 - This adapter now supports Harlequin's `--read-only` option and declares `IMPLEMENTS_READ_ONLY`. Read-only connections are enforced by the server, using `set session characteristics as transaction read only` ([#58](https://github.com/tconbeer/harlequin-postgres/issues/58)).

--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -575,6 +575,29 @@ class HarlequinPostgresConnection(HarlequinConnection):
         self.pool.putconn(conn)
         return results
 
+    def _get_all_columns(self, dbname: str, schema: str) -> list[tuple[str, str, str]]:
+        """
+        Returns (relation_name, column_name, data_type) for every table and
+        view in the schema, in one round trip. Materialized views are not
+        included (information_schema does not cover them).
+        """
+        conn: Connection = self.pool.getconn()
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                select table_name, column_name, data_type
+                from information_schema.columns
+                where
+                    table_catalog = %s
+                    and table_schema = %s
+                order by table_name asc, ordinal_position asc
+                ;""",
+                (dbname, schema),
+            )
+            results: list[tuple[str, str, str]] = cur.fetchall()
+        self.pool.putconn(conn)
+        return results
+
     def _get_columns(
         self, dbname: str, schema: str, relation: str
     ) -> list[tuple[str, str]]:

--- a/src/harlequin_postgres/catalog.py
+++ b/src/harlequin_postgres/catalog.py
@@ -294,7 +294,47 @@ class SchemaCatalogItem(InteractiveCatalogItem["HarlequinPostgresConnection"]):
                 )
             )
 
+        self._attach_columns(children)
         return children
+
+    def _attach_columns(self, children: list[RelationCatalogItem]) -> None:
+        """
+        Fetches the columns for every table and view in this schema in a
+        single round trip and attaches them to the child items, so each
+        relation doesn't need its own query (a big win on high-latency
+        connections). Materialized views are not covered by
+        information_schema and keep their per-item lazy load, as does any
+        relation missing from the batch result.
+        """
+        if self.parent is None or self.connection is None:
+            return
+        try:
+            all_columns = self.connection._get_all_columns(
+                self.parent.label, self.label
+            )
+        except Exception:
+            # fall back to per-relation lazy loading
+            return
+        columns_by_relation: dict[str, list[tuple[str, str]]] = {}
+        for relation_name, column_name, column_type in all_columns:
+            columns_by_relation.setdefault(relation_name, []).append(
+                (column_name, column_type)
+            )
+        for child in children:
+            if isinstance(child, MaterializedViewCatalogItem):
+                continue
+            columns = columns_by_relation.get(child.label)
+            if columns is None:
+                continue
+            child.children = [
+                ColumnCatalogItem.from_parent(
+                    parent=child,
+                    label=column_name,
+                    type_label=self.connection._short_column_type(column_type),
+                )
+                for column_name, column_type in columns
+            ]
+            child.loaded = True
 
 
 class DatabaseCatalogItem(InteractiveCatalogItem["HarlequinPostgresConnection"]):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -61,11 +61,18 @@ def test_catalog(connection_with_objects: HarlequinPostgresConnection) -> None:
 
     [foo_item] = filter(lambda item: item.label == "foo", table_items)
     assert isinstance(foo_item, TableCatalogItem)
-    assert not foo_item.children
-    assert not foo_item.loaded
+    # columns are batch-loaded for the whole schema when the schema's
+    # children are fetched, so tables arrive with their columns attached.
+    assert foo_item.children
+    assert foo_item.loaded
+    assert all(isinstance(item, ColumnCatalogItem) for item in foo_item.children)
 
     foo_column_items = foo_item.fetch_children()
     assert all(isinstance(item, ColumnCatalogItem) for item in foo_column_items)
+    # the batch-loaded columns match a direct fetch
+    assert [item.label for item in foo_item.children] == [
+        item.label for item in foo_column_items
+    ]
 
     [schema_two_item] = filter(lambda item: item.label == "two", schema_items)
     assert isinstance(schema_two_item, SchemaCatalogItem)
@@ -77,8 +84,9 @@ def test_catalog(connection_with_objects: HarlequinPostgresConnection) -> None:
 
     [qux_item] = filter(lambda item: item.label == "qux", view_items)
     assert isinstance(qux_item, ViewCatalogItem)
-    assert not qux_item.children
-    assert not qux_item.loaded
+    # views get batch-loaded columns, too
+    assert qux_item.children
+    assert qux_item.loaded
 
     qux_column_items = qux_item.fetch_children()
     assert all(isinstance(item, ColumnCatalogItem) for item in qux_column_items)
@@ -109,6 +117,8 @@ def test_catalog(connection_with_objects: HarlequinPostgresConnection) -> None:
 
     [foo_mv_item] = filter(lambda item: item.label == "foo", mview_items)
     assert isinstance(foo_mv_item, MaterializedViewCatalogItem)
+    # materialized views are not covered by information_schema, so they
+    # keep their per-item lazy load
     assert not foo_mv_item.children
     assert not foo_mv_item.loaded
 


### PR DESCRIPTION
**What:** When a schema's children are fetched for the Data Catalog, this PR now runs a single `information_schema.columns` query for the whole schema and attaches the columns to every table/view item it returns (marking them `loaded`), instead of leaving each relation to lazy-load its own columns with a separate query.

**Why:** Harlequin's Data Catalog prefetches each relation's children in the background, so with the per-relation lazy load, expanding a schema with N tables issues N serialized round trips. On a local database that's invisible; over a ~50ms-latency connection (e.g. an RDS instance) it keeps the catalog loader busy for many seconds and floods the app with per-node updates. With this change, browsing a schema costs 3 round trips (relations + matviews + columns) instead of N+2.

Freshness semantics are unchanged — columns are still fetched live at the moment the schema is expanded.

**Edge cases:** Materialized views aren't covered by `information_schema.columns`, so they keep their per-item lazy load (via `_get_mv_cols`), as does any relation missing from the batch result (the batch is also wrapped in a try/except that falls back to per-relation lazy loading).

**Tests:** Updated `test_catalog` to assert tables/views arrive with columns attached and that the batch-loaded columns exactly match a direct `fetch_children()` call; matviews are asserted to remain lazy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EecCPQjLNeHoYHCRQ8QJkZ