### PR TITLE
feat: honor a read_only option and declare IMPLEMENTS_READ_ONLY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- This adapter now supports Harlequin's `--read-only` option and declares `IMPLEMENTS_READ_ONLY`. Read-only connections are enforced by the server, using `default_transaction_read_only` ([#58](https://github.com/tconbeer/harlequin-postgres/issues/58)).
+
 ## [1.3.1] - 2026-04-19
 
 - Fixes a bug causing user schemas starting with "pg" to be filtered out of the catalog. (#50)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- This adapter now supports Harlequin's `--read-only` option and declares `IMPLEMENTS_READ_ONLY`. Read-only connections are enforced by the server, using `default_transaction_read_only` ([#58](https://github.com/tconbeer/harlequin-postgres/issues/58)).
+- This adapter now supports Harlequin's `--read-only` option and declares `IMPLEMENTS_READ_ONLY`. Read-only connections are enforced by the server, using `set session characteristics as transaction read only` ([#58](https://github.com/tconbeer/harlequin-postgres/issues/58)).
 
 ## [1.3.1] - 2026-04-19
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This adapter supports Harlequin's `--read-only` option:
 harlequin --read-only -a postgres "postgres://my-user:my-pass@localhost:5432/my-database"
 ```
 
-Harlequin connects with `default_transaction_read_only=on`, so the server rejects any statement that would write. The setting is applied to every connection this adapter opens, and it is enforced in both Auto and Manual transaction modes. If the server does not report that setting as `on` after connecting, Harlequin refuses to start.
+Every connection this adapter opens is configured with `set session characteristics as transaction read only`, so the server rejects any statement that would write, in both Auto and Manual transaction modes. If the server does not report `default_transaction_read_only` as `on` after connecting, Harlequin refuses to start.
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ For descriptions of each option, run:
 harlequin --help
 ```
 
+## Read-Only Mode
+
+This adapter supports Harlequin's `--read-only` option:
+
+```bash
+harlequin --read-only -a postgres "postgres://my-user:my-pass@localhost:5432/my-database"
+```
+
+Harlequin connects with `default_transaction_read_only=on`, so the server rejects any statement that would write. The setting is applied to every connection this adapter opens, and it is enforced in both Auto and Manual transaction modes. If the server does not report that setting as `on` after connecting, Harlequin refuses to start.
+
 ## Environment Variables
 
 Harlequin's Postgres driver will load connection information from the standard `PG*` environment variables. Any options supplied at the command-line will override environment variables.

--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -23,6 +23,13 @@ from harlequin_postgres.cli_options import POSTGRES_OPTIONS
 from harlequin_postgres.completions import _get_completions
 from harlequin_postgres.loaders import register_inf_loaders
 
+READ_ONLY_CONN_OPTION = "-c default_transaction_read_only=on"
+"""
+Libpq allows arbitrary command-line options to be passed to the server at
+connection time; ``default_transaction_read_only`` is the setting Postgres
+enforces read-only sessions with.
+"""
+
 
 class HarlequinPostgresCursor(HarlequinCursor):
     def __init__(self, conn: HarlequinPostgresConnection, cur: Cursor) -> None:
@@ -68,8 +75,10 @@ class HarlequinPostgresConnection(HarlequinConnection):
         *_: Any,
         init_message: str = "",
         options: dict[str, Any],
+        read_only: bool = False,
     ) -> None:
         self.init_message = init_message
+        self.read_only = bool(read_only)
         try:
             self.conn_info = conninfo.conninfo_to_dict(
                 conninfo=conn_str[0] if conn_str else "", **options
@@ -93,14 +102,24 @@ class HarlequinPostgresConnection(HarlequinConnection):
                     "Invalid value for connection_timeout."
                 ),
             ) from e
+        pool_kwargs = dict(options)
+        if self.read_only:
+            # read_only is not a libpq conninfo key, so it can never be passed
+            # to psycopg as an option; instead we ask the server to make every
+            # transaction on every connection in the pool read-only.
+            pool_kwargs["options"] = self._read_only_conn_options(
+                self.conn_info.get("options")
+            )
+            self.conn_info["options"] = pool_kwargs["options"]
         try:
             self.pool: ConnectionPool = ConnectionPool(
                 conninfo=conn_str[0] if conn_str and conn_str[0] else "",
                 min_size=2,
                 max_size=5,
-                kwargs=options,
+                kwargs=pool_kwargs,
                 open=True,
                 timeout=timeout,
+                configure=self._configure_connection,
             )
             self._main_conn: Connection = self.pool.getconn()
         except Exception as e:
@@ -119,6 +138,59 @@ class HarlequinPostgresConnection(HarlequinConnection):
             ]
         )
         self.toggle_transaction_mode()
+
+        if self.read_only:
+            try:
+                self._assert_read_only()
+            except HarlequinConnectionError:
+                self.close()
+                raise
+
+    @staticmethod
+    def _read_only_conn_options(existing: Any = None) -> str:
+        """
+        Adds the read-only setting to any command-line options already present in
+        the conninfo. Postgres uses the last value for a repeated setting, so this
+        overrides a conflicting value passed by the user.
+        """
+        existing_options = str(existing).strip() if existing else ""
+        return f"{existing_options} {READ_ONLY_CONN_OPTION}".strip()
+
+    def _configure_connection(self, conn: Connection) -> None:
+        """
+        Called by the pool for every connection it creates. Must leave the
+        connection idle (outside of a transaction).
+        """
+        if self.read_only:
+            # belt-and-suspenders: this does not execute any statements; it makes
+            # psycopg add READ ONLY to the transactions that it starts.
+            conn.read_only = True
+
+    def _assert_read_only(self) -> None:
+        """
+        Confirms the server is actually enforcing read-only transactions, so this
+        adapter never claims to implement a guarantee that it did not deliver.
+        """
+        try:
+            with self._main_conn.cursor() as cur:
+                cur.execute("select current_setting('default_transaction_read_only');")
+                result = cur.fetchone()
+            setting = result[0] if result else None
+        except Exception as e:
+            raise HarlequinConnectionError(
+                msg=str(e),
+                title="Harlequin could not open a read-only connection to Postgres.",
+            ) from e
+        if setting != "on":
+            raise HarlequinConnectionError(
+                msg=(
+                    "Harlequin requested a read-only connection, but this server "
+                    "reports default_transaction_read_only is "
+                    f"{setting!r}. Refusing to connect, since writes would not "
+                    "be prevented."
+                ),
+                title="Harlequin could not open a read-only connection to Postgres.",
+            )
 
     def execute(self, query: str) -> HarlequinCursor | None:
         if (
@@ -442,10 +514,12 @@ class HarlequinPostgresConnection(HarlequinConnection):
 class HarlequinPostgresAdapter(HarlequinAdapter):
     ADAPTER_OPTIONS = POSTGRES_OPTIONS
     IMPLEMENTS_CANCEL = True
+    IMPLEMENTS_READ_ONLY = True
 
     def __init__(
         self,
         conn_str: Sequence[str],
+        read_only: bool = False,
         host: str | None = None,
         port: str | None = None,
         dbname: str | None = None,
@@ -461,6 +535,7 @@ class HarlequinPostgresAdapter(HarlequinAdapter):
         **_: Any,
     ) -> None:
         self.conn_str = conn_str
+        self.read_only = bool(read_only)
         self.options: dict[str, str | int | None] = {
             "host": host,
             "port": port,
@@ -503,5 +578,7 @@ class HarlequinPostgresAdapter(HarlequinAdapter):
         # before creating the connection, register updated type adapters, so
         # all subsequent connections will use those adapters
         register_inf_loaders()
-        conn = HarlequinPostgresConnection(self.conn_str, options=self.options)
+        conn = HarlequinPostgresConnection(
+            self.conn_str, options=self.options, read_only=self.read_only
+        )
         return conn

--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -23,13 +23,6 @@ from harlequin_postgres.cli_options import POSTGRES_OPTIONS
 from harlequin_postgres.completions import _get_completions
 from harlequin_postgres.loaders import register_inf_loaders
 
-READ_ONLY_CONN_OPTION = "-c default_transaction_read_only=on"
-"""
-Libpq allows arbitrary command-line options to be passed to the server at
-connection time; ``default_transaction_read_only`` is the setting Postgres
-enforces read-only sessions with.
-"""
-
 
 class HarlequinPostgresCursor(HarlequinCursor):
     def __init__(self, conn: HarlequinPostgresConnection, cur: Cursor) -> None:
@@ -102,21 +95,12 @@ class HarlequinPostgresConnection(HarlequinConnection):
                     "Invalid value for connection_timeout."
                 ),
             ) from e
-        pool_kwargs = dict(options)
-        if self.read_only:
-            # read_only is not a libpq conninfo key, so it can never be passed
-            # to psycopg as an option; instead we ask the server to make every
-            # transaction on every connection in the pool read-only.
-            pool_kwargs["options"] = self._read_only_conn_options(
-                self.conn_info.get("options")
-            )
-            self.conn_info["options"] = pool_kwargs["options"]
         try:
             self.pool: ConnectionPool = ConnectionPool(
                 conninfo=conn_str[0] if conn_str and conn_str[0] else "",
                 min_size=2,
                 max_size=5,
-                kwargs=pool_kwargs,
+                kwargs=options,
                 open=True,
                 timeout=timeout,
                 configure=self._configure_connection,
@@ -146,25 +130,24 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 self.close()
                 raise
 
-    @staticmethod
-    def _read_only_conn_options(existing: Any = None) -> str:
-        """
-        Adds the read-only setting to any command-line options already present in
-        the conninfo. Postgres uses the last value for a repeated setting, so this
-        overrides a conflicting value passed by the user.
-        """
-        existing_options = str(existing).strip() if existing else ""
-        return f"{existing_options} {READ_ONLY_CONN_OPTION}".strip()
-
     def _configure_connection(self, conn: Connection) -> None:
         """
-        Called by the pool for every connection it creates. Must leave the
-        connection idle (outside of a transaction).
+        Called by the pool for every connection that it creates, so that read-only
+        mode is enforced by every connection, not just the main one. Must leave
+        the connection idle (outside of a transaction).
         """
-        if self.read_only:
-            # belt-and-suspenders: this does not execute any statements; it makes
-            # psycopg add READ ONLY to the transactions that it starts.
-            conn.read_only = True
+        if not self.read_only:
+            return
+        # psycopg's conn.read_only only adds READ ONLY to the transactions that
+        # psycopg itself begins, so it does nothing in an autocommit session,
+        # where psycopg never issues a BEGIN. SET SESSION CHARACTERISTICS sets
+        # default_transaction_read_only for the whole session instead, which the
+        # server enforces in both of our transaction modes.
+        conn.execute("set session characteristics as transaction read only;")
+        conn.commit()
+        # additionally declare the transactions psycopg begins READ ONLY, so
+        # Manual mode is still read-only if the session setting is changed.
+        conn.read_only = True
 
     def _assert_read_only(self) -> None:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,3 +39,19 @@ def connection() -> Generator[HarlequinPostgresConnection, None, None]:
     cur.execute("drop database if exists test;")
     cur.close()
     pgconn.close()
+
+
+@pytest.fixture
+def read_only_connection(
+    connection: HarlequinPostgresConnection,
+) -> Generator[HarlequinPostgresConnection, None, None]:
+    """
+    A read-only connection to the same (read-write provisioned) test database.
+    """
+    connection.execute("create table foo (a int)")
+    connection.execute("insert into foo values (1)")
+    ro_conn = HarlequinPostgresAdapter(
+        conn_str=(f"{TEST_DB_CONN}",), dbname="test", read_only=True
+    ).connect()
+    yield ro_conn
+    ro_conn.close()

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -198,24 +198,12 @@ def test_read_only_is_not_a_conn_info_option() -> None:
     assert "read_only" not in adapter.options
     assert adapter.connection_id == "localhost:5432/postgres"
 
-
-@pytest.mark.parametrize(
-    "existing,expected",
-    [
-        (None, "-c default_transaction_read_only=on"),
-        ("", "-c default_transaction_read_only=on"),
-        (
-            "-c statement_timeout=5000",
-            "-c statement_timeout=5000 -c default_transaction_read_only=on",
-        ),
-        (
-            "-c default_transaction_read_only=off",
-            "-c default_transaction_read_only=off -c default_transaction_read_only=on",
-        ),
-    ],
-)
-def test_read_only_conn_options(existing: str | None, expected: str) -> None:
-    assert HarlequinPostgresConnection._read_only_conn_options(existing) == expected
+    conn = adapter.connect()
+    # the conninfo passed to psycopg is unchanged; read-only is applied to each
+    # connection after it is opened.
+    assert "read_only" not in conn.conn_info
+    assert "options" not in conn.conn_info
+    conn.close()
 
 
 def test_read_only_connection_can_read(
@@ -288,8 +276,21 @@ def test_read_only_refuses_to_connect_if_server_does_not_enforce(
     """
     monkeypatch.setattr(
         HarlequinPostgresConnection,
-        "_read_only_conn_options",
-        staticmethod(lambda existing=None: ""),
+        "_configure_connection",
+        lambda self, conn: None,
     )
     with pytest.raises(HarlequinConnectionError):
         HarlequinPostgresAdapter(conn_str=(TEST_DB_CONN,), read_only=True).connect()
+
+
+def test_read_only_enforced_in_autocommit_session(
+    read_only_connection: HarlequinPostgresConnection,
+) -> None:
+    """
+    psycopg's Connection.read_only does not affect autocommit sessions, since
+    psycopg never issues a BEGIN for them; the session characteristic does.
+    """
+    assert read_only_connection.transaction_mode.label == "Auto"
+    assert read_only_connection._main_conn.autocommit is True
+    with pytest.raises(HarlequinQueryError):
+        read_only_connection.execute("insert into foo values (2)")

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import sys
 from datetime import date, datetime
 
+import psycopg
 import pytest
 from harlequin.adapter import HarlequinAdapter, HarlequinConnection, HarlequinCursor
 from harlequin.catalog import Catalog, CatalogItem
@@ -174,3 +175,121 @@ def test_closed_conn_raises_right_error(
 
     with pytest.raises(HarlequinQueryError):
         connection.execute("select 1")
+
+
+def test_implements_read_only() -> None:
+    assert HarlequinPostgresAdapter.IMPLEMENTS_READ_ONLY is True
+
+
+def test_read_only_defaults_to_false() -> None:
+    adapter = HarlequinPostgresAdapter(conn_str=(TEST_DB_CONN,))
+    assert adapter.read_only is False
+    conn = adapter.connect()
+    assert conn.read_only is False
+    conn.close()
+
+
+def test_read_only_is_not_a_conn_info_option() -> None:
+    """
+    read_only is not a libpq conninfo key, so it must never be passed to psycopg.
+    """
+    adapter = HarlequinPostgresAdapter(conn_str=(TEST_DB_CONN,), read_only=True)
+    assert adapter.read_only is True
+    assert "read_only" not in adapter.options
+    assert adapter.connection_id == "localhost:5432/postgres"
+
+
+@pytest.mark.parametrize(
+    "existing,expected",
+    [
+        (None, "-c default_transaction_read_only=on"),
+        ("", "-c default_transaction_read_only=on"),
+        (
+            "-c statement_timeout=5000",
+            "-c statement_timeout=5000 -c default_transaction_read_only=on",
+        ),
+        (
+            "-c default_transaction_read_only=off",
+            "-c default_transaction_read_only=off -c default_transaction_read_only=on",
+        ),
+    ],
+)
+def test_read_only_conn_options(existing: str | None, expected: str) -> None:
+    assert HarlequinPostgresConnection._read_only_conn_options(existing) == expected
+
+
+def test_read_only_connection_can_read(
+    read_only_connection: HarlequinPostgresConnection,
+) -> None:
+    assert read_only_connection.read_only is True
+    cur = read_only_connection.execute("select * from foo")
+    assert isinstance(cur, HarlequinCursor)
+    assert cur.fetchall() == [(1,)]
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "insert into foo values (2)",
+        "update foo set a = 2",
+        "delete from foo",
+        "create table bar (a int)",
+        "drop table foo",
+    ],
+)
+def test_read_only_connection_rejects_writes(
+    read_only_connection: HarlequinPostgresConnection, query: str
+) -> None:
+    with pytest.raises(HarlequinQueryError):
+        read_only_connection.execute(query)
+
+
+def test_read_only_survives_transaction_mode_toggle(
+    read_only_connection: HarlequinPostgresConnection,
+) -> None:
+    assert read_only_connection.transaction_mode.label == "Auto"
+    for _ in range(4):
+        with pytest.raises(HarlequinQueryError):
+            read_only_connection.execute("insert into foo values (2)")
+        read_only_connection.toggle_transaction_mode()
+
+
+def test_read_only_applies_to_pooled_connections(
+    read_only_connection: HarlequinPostgresConnection,
+) -> None:
+    # the catalog and completions run on connections from the pool, not on the
+    # main connection.
+    conn = read_only_connection.pool.getconn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("select current_setting('default_transaction_read_only')")
+            assert cur.fetchone() == ("on",)
+            with pytest.raises(psycopg.errors.ReadOnlySqlTransaction):
+                cur.execute("create table baz (a int)")
+        conn.rollback()
+    finally:
+        read_only_connection.pool.putconn(conn)
+
+
+def test_read_only_connection_get_catalog(
+    read_only_connection: HarlequinPostgresConnection,
+) -> None:
+    catalog = read_only_connection.get_catalog()
+    assert isinstance(catalog, Catalog)
+    assert catalog.items
+
+
+def test_read_only_refuses_to_connect_if_server_does_not_enforce(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    If the read-only setting does not make it to the server, connecting must fail
+    loudly, rather than hand back a connection that would happily write.
+    """
+    monkeypatch.setattr(
+        HarlequinPostgresConnection,
+        "_read_only_conn_options",
+        staticmethod(lambda existing=None: ""),
+    )
+    with pytest.raises(HarlequinConnectionError):
+        HarlequinPostgresAdapter(conn_str=(TEST_DB_CONN,), read_only=True).connect()


### PR DESCRIPTION
closes #58

- **feat: honor a read_only option and declare IMPLEMENTS_READ_ONLY**
- **refactor: enforce read-only per connection, not via the conn string**
- **chore: update changelog and README**

## What changed

- `HarlequinPostgresAdapter.__init__` takes `read_only: bool = False` (second positional, matching core's signature) and keeps it on `self.read_only` — deliberately **not** in `self.options`, since `read_only` is not a libpq conninfo key and must never reach `conninfo_to_dict()`.
- `IMPLEMENTS_READ_ONLY = True` on the adapter class.
- `HarlequinPostgresConnection` takes `read_only` and enforces it in the pool's `configure=` callback, so it applies to every connection the pool opens, not just `_main_conn`:

```python
conn.execute("set session characteristics as transaction read only;")
conn.commit()   # leaves the connection idle, as the pool requires
conn.read_only = True
```

- After connecting, `_assert_read_only()` confirms the server reports `default_transaction_read_only` as `on`, and raises `HarlequinConnectionError` (closing the pool first) if it does not — so this adapter never declares an enforcement it did not actually deliver.

The connection string is passed to psycopg untouched.

## Why not just `conn.read_only`

psycopg's `Connection.read_only` is a *transaction* characteristic: psycopg applies it by appending `READ ONLY` to the `BEGIN` it issues. Harlequin's default **Auto** transaction mode is an autocommit session, where psycopg never issues a `BEGIN`, so the attribute is inert there ([psycopg docs](https://www.psycopg.org/psycopg3/docs/basic/from_pg2.html#transaction-characteristics-attributes-don-t-affect-autocommit-sessions)). Probed against a live server:

| session | mechanism | `insert` |
|---|---|---|
| autocommit (**Auto**) | `conn.read_only = True` only | **succeeded — not enforced** |
| non-autocommit (**Manual**) | `conn.read_only = True` only | blocked |
| autocommit (**Auto**) | `set session characteristics as transaction read only` | blocked |

`SET SESSION CHARACTERISTICS` sets `default_transaction_read_only` for the session, which the server enforces in both transaction modes, so the Auto/Manual toggle keeps working as it does today and read-only survives toggling. `conn.read_only` is still set as defense in depth: `default_transaction_read_only` is `USERSET`, so if someone changes it from the editor, Manual mode still gets `BEGIN … READ ONLY`.

## Testing

Ran against a local Postgres 16: 38 tests pass, `ruff` and `mypy` clean. New tests cover reads succeeding; `insert`/`update`/`delete`/`create`/`drop` all rejected; enforcement across four transaction-mode toggles; pooled (catalog/completion) connections read-only; `read_only` absent from the adapter options and from the conninfo; and — with the configure callback monkeypatched out — that the connection refuses to open rather than proceeding unenforced. One test pins the autocommit case specifically, so the gap above cannot regress silently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXgi96udVPsMUwx87xEbwK)_