### PR TITLE
feat: implement search_catalog() and declare IMPLEMENTS_CATALOG_SEARCH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - This adapter now supports Harlequin's `--read-only` option and declares `IMPLEMENTS_READ_ONLY`. Read-only connections are enforced by the server, using `set session characteristics as transaction read only` ([#58](https://github.com/tconbeer/harlequin-postgres/issues/58)).
+- This adapter now implements `search_catalog()` and declares `IMPLEMENTS_CATALOG_SEARCH`, so `hsql --catalog-search TERM` finds databases, schemas, relations (including materialized views), and columns in one query, instead of walking the catalog a level at a time ([#59](https://github.com/tconbeer/harlequin-postgres/issues/59)).
+- This adapter now requires `harlequin>=2.11`, the first version with `CatalogSearchResult`.
 
 ## [1.3.1] - 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - This adapter now supports Harlequin's `--read-only` option and declares `IMPLEMENTS_READ_ONLY`. Read-only connections are enforced by the server, using `set session characteristics as transaction read only` ([#58](https://github.com/tconbeer/harlequin-postgres/issues/58)).
 - This adapter now implements `search_catalog()` and declares `IMPLEMENTS_CATALOG_SEARCH`, so `hsql --catalog-search TERM` finds databases, schemas, relations (including materialized views), and columns in one query, instead of walking the catalog a level at a time ([#59](https://github.com/tconbeer/harlequin-postgres/issues/59)).
+- Catalog items now set `type_name`, the full type that their short `type_label` is shortened from: `BASE TABLE`, `VIEW`, `MATERIALIZED VIEW`, etc. for relations, and the column's type, as Postgres spells it, for columns.
 - This adapter now requires `harlequin>=2.11`, the first version with `CatalogSearchResult`.
 
 ## [1.3.1] - 2026-04-19

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ harlequin --read-only -a postgres "postgres://my-user:my-pass@localhost:5432/my-
 
 Every connection this adapter opens is configured with `set session characteristics as transaction read only`, so the server rejects any statement that would write, in both Auto and Manual transaction modes. If the server does not report `default_transaction_read_only` as `on` after connecting, Harlequin refuses to start.
 
+## Catalog Search
+
+This adapter implements `search_catalog()`, so you can find an object without walking the catalog a level at a time:
+
+```bash
+hsql -a postgres "postgres://my-user:my-pass@localhost:5432/my-database" --catalog-search orders
+```
+
+A term matches a database, schema, relation, or column whose name contains it, case-insensitively. Relations and columns come from the connected database, since that is the database the catalog shows them for; the other databases on the server are matched by name, which is all the catalog's top level shows for them.
+
 ## Environment Variables
 
 Harlequin's Postgres driver will load connection information from the standard `PG*` environment variables. Any options supplied at the command-line will override environment variables.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ license = "MIT"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "harlequin>=1.25,<3",
+    # 2.11 is the first version with CatalogSearchResult, which search_catalog returns
+    "harlequin>=2.11,<3",
     "psycopg[binary,pool]>=3.2,<4",
     # temp pin to allow prerelease versions
     "duckdb>=1.4.2.dev0; python_version>='3.14'"
@@ -20,7 +21,7 @@ postgres = "harlequin_postgres:HarlequinPostgresAdapter"
 
 [dependency-groups]
 dev = [
-    "harlequin==2.4.0",
+    "harlequin==2.11.0",
     "ruff>=0.5,<1",
     "pytest>=7.4.3,<8",
     "mypy>=1.10.0,<2",

--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -10,18 +10,168 @@ from harlequin import (
     HarlequinCursor,
     HarlequinTransactionMode,
 )
-from harlequin.catalog import Catalog, CatalogItem
+from harlequin.catalog import (
+    Catalog,
+    CatalogItem,
+    CatalogSearchKind,
+    CatalogSearchResult,
+)
 from harlequin.exception import HarlequinConnectionError, HarlequinQueryError
 from psycopg import Connection, Cursor, conninfo
-from psycopg.errors import QueryCanceled
+from psycopg.errors import Error, QueryCanceled
 from psycopg.pq import TransactionStatus
 from psycopg_pool import ConnectionPool
 from textual_fastdatatable.backend import AutoBackendType
 
-from harlequin_postgres.catalog import DatabaseCatalogItem
+from harlequin_postgres.catalog import (
+    ColumnCatalogItem,
+    DatabaseCatalogItem,
+    ForeignCatalogItem,
+    MaterializedViewCatalogItem,
+    RelationCatalogItem,
+    SchemaCatalogItem,
+    TableCatalogItem,
+    TempTableCatalogItem,
+    ViewCatalogItem,
+)
 from harlequin_postgres.cli_options import POSTGRES_OPTIONS
 from harlequin_postgres.completions import _get_completions
 from harlequin_postgres.loaders import register_inf_loaders
+
+_LIKE_ESCAPE = "\\"
+"""What escapes a LIKE metacharacter in a term the caller typed."""
+
+_MATERIALIZED_VIEW = "MATERIALIZED VIEW"
+"""A relation type for matviews, which information_schema.tables does not have."""
+
+
+def _user_schemas(column: str) -> str:
+    """The schemas the catalog shows, as a predicate on `column`.
+
+    The same filter `_get_schemas()` applies, so a search only reports paths
+    that `--catalog` also walks. The `%` is doubled because these queries are
+    executed with parameters.
+    """
+    return (
+        f"{column} != 'information_schema' and {column} not like 'pg\\_%%' escape '\\'"
+    )
+
+
+_SEARCH_DATABASES = """
+select d.datname::text, null::text, null::text, null::text, null::text, null::text
+from pg_database d
+where
+    d.datistemplate is false
+    and d.datallowconn is true
+    and d.datname ilike %s escape '\\'
+"""
+"""The databases on the server, which is the catalog's top level.
+
+The pool is bound to one database, so every level below this one is the
+connected database's; the others can still be matched by name, which is all
+`_get_databases()` reads for them.
+"""
+
+_SEARCH_SCHEMAS = f"""
+select
+    s.catalog_name::text, s.schema_name::text,
+    null::text, null::text, null::text, null::text
+from information_schema.schemata s
+where
+    s.catalog_name = current_database()
+    and {_user_schemas("s.schema_name")}
+    and s.schema_name ilike %s escape '\\'
+"""
+
+_SEARCH_RELATIONS = f"""
+select
+    t.table_catalog::text, t.table_schema::text, t.table_name::text,
+    t.table_type::text, null::text, null::text
+from information_schema.tables t
+where
+    t.table_catalog = current_database()
+    and {_user_schemas("t.table_schema")}
+    and t.table_name ilike %s escape '\\'
+"""
+
+_SEARCH_MATERIALIZED_VIEWS = f"""
+select
+    current_database()::text, m.schemaname::text, m.matviewname::text,
+    '{_MATERIALIZED_VIEW}'::text, null::text, null::text
+from pg_matviews m
+where
+    {_user_schemas("m.schemaname")}
+    and m.matviewname ilike %s escape '\\'
+"""
+"""Matviews are not in information_schema, the same reason `_get_mvs()` exists."""
+
+_SEARCH_COLUMNS = f"""
+select
+    c.table_catalog::text, c.table_schema::text, c.table_name::text,
+    t.table_type::text, c.column_name::text, c.data_type::text
+from information_schema.columns c
+join information_schema.tables t
+    on t.table_catalog = c.table_catalog
+    and t.table_schema = c.table_schema
+    and t.table_name = c.table_name
+where
+    c.table_catalog = current_database()
+    and {_user_schemas("c.table_schema")}
+    and c.column_name ilike %s escape '\\'
+"""
+
+_SEARCH_MATERIALIZED_VIEW_COLUMNS = f"""
+select
+    current_database()::text, s.nspname::text, t.relname::text,
+    '{_MATERIALIZED_VIEW}'::text, a.attname::text,
+    pg_catalog.format_type(a.atttypid, a.atttypmod)::text
+from pg_attribute a
+join pg_class t on a.attrelid = t.oid
+join pg_namespace s on t.relnamespace = s.oid
+where
+    t.relkind = 'm'
+    and a.attnum > 0
+    and not a.attisdropped
+    and {_user_schemas("s.nspname")}
+    and a.attname ilike %s escape '\\'
+"""
+"""The matview equivalent of `_SEARCH_COLUMNS`, shaped like `_get_mv_cols()`."""
+
+_SEARCH_BRANCHES: dict[CatalogSearchKind, tuple[str, ...]] = {
+    "relations": (_SEARCH_RELATIONS, _SEARCH_MATERIALIZED_VIEWS),
+    "columns": (_SEARCH_COLUMNS, _SEARCH_MATERIALIZED_VIEW_COLUMNS),
+    "all": (
+        _SEARCH_DATABASES,
+        _SEARCH_SCHEMAS,
+        _SEARCH_RELATIONS,
+        _SEARCH_MATERIALIZED_VIEWS,
+        _SEARCH_COLUMNS,
+        _SEARCH_MATERIALIZED_VIEW_COLUMNS,
+    ),
+}
+"""Which levels each kind unions, every branch in the same six columns.
+
+A row names one item by filling in the levels above it and leaving the rest
+null, so `all` is every level of the catalog rather than the two at the bottom.
+Each branch binds the pattern exactly once, in this order.
+"""
+
+_SEARCH_SQL = {
+    kind: " union all ".join(branches)
+    # `nulls first` explicitly, because Postgres sorts nulls last ascending:
+    # without it a schema would arrive after the relations under it.
+    + " order by 1, 2 nulls first, 3 nulls first, 5 nulls first"
+    for kind, branches in _SEARCH_BRANCHES.items()
+}
+"""One query per kind, ordered so that an item arrives before its children."""
+
+
+def _contains_pattern(term: str) -> str:
+    """A term as the LIKE pattern that matches any label containing it."""
+    escaped = term
+    for character in (_LIKE_ESCAPE, "%", "_"):
+        escaped = escaped.replace(character, f"{_LIKE_ESCAPE}{character}")
+    return f"%{escaped}%"
 
 
 class HarlequinPostgresCursor(HarlequinCursor):
@@ -229,6 +379,90 @@ class HarlequinPostgresConnection(HarlequinConnection):
             for (db,) in databases
         ]
         return Catalog(items=db_items)
+
+    def search_catalog(
+        self, term: str, kind: CatalogSearchKind = "all"
+    ) -> list[CatalogSearchResult]:
+        pattern = _contains_pattern(term)
+        parameters = [pattern] * len(_SEARCH_BRANCHES[kind])
+        conn: Connection = self.pool.getconn()
+        try:
+            with conn.cursor() as cur:
+                cur.execute(_SEARCH_SQL[kind], parameters)
+                found: list[
+                    tuple[
+                        str,
+                        str | None,
+                        str | None,
+                        str | None,
+                        str | None,
+                        str | None,
+                    ]
+                ] = cur.fetchall()
+        except Error as e:
+            raise HarlequinQueryError(
+                msg=str(e), title="Postgres raised an error searching the catalog:"
+            ) from e
+        finally:
+            self.pool.putconn(conn)
+
+        databases: dict[str, DatabaseCatalogItem] = {}
+        schemas: dict[tuple[str, str], SchemaCatalogItem] = {}
+        relations: dict[tuple[str, str, str], RelationCatalogItem] = {}
+        results: list[CatalogSearchResult] = []
+        # a row names the deepest level it fills in, and carries its ancestors
+        # so that each one is built once and the match knows its own path
+        for catalog, schema, relation, relation_type, column, column_type in found:
+            database_item = databases.setdefault(
+                catalog, DatabaseCatalogItem.from_label(label=catalog, connection=self)
+            )
+            if schema is None:
+                results.append(CatalogSearchResult(item=database_item))
+                continue
+            schema_item = schemas.setdefault(
+                (catalog, schema),
+                SchemaCatalogItem.from_parent(parent=database_item, label=schema),
+            )
+            if relation is None:
+                results.append(
+                    CatalogSearchResult(item=schema_item, parents=(catalog,))
+                )
+                continue
+            relation_item = relations.setdefault(
+                (catalog, schema, relation),
+                self._relation_item(schema_item, relation, relation_type),
+            )
+            if column is None:
+                results.append(
+                    CatalogSearchResult(item=relation_item, parents=(catalog, schema))
+                )
+                continue
+            results.append(
+                CatalogSearchResult(
+                    item=ColumnCatalogItem.from_parent(
+                        parent=relation_item,
+                        label=column,
+                        type_label=self._short_column_type(column_type or ""),
+                    ),
+                    parents=(catalog, schema, relation),
+                )
+            )
+        return results
+
+    @staticmethod
+    def _relation_item(
+        parent: SchemaCatalogItem, label: str, relation_type: str | None
+    ) -> RelationCatalogItem:
+        """A relation of the class `fetch_children()` would have built for it."""
+        if relation_type == "VIEW":
+            return ViewCatalogItem.from_parent(parent=parent, label=label)
+        if relation_type == "LOCAL TEMPORARY":
+            return TempTableCatalogItem.from_parent(parent=parent, label=label)
+        if relation_type == "FOREIGN":
+            return ForeignCatalogItem.from_parent(parent=parent, label=label)
+        if relation_type == _MATERIALIZED_VIEW:
+            return MaterializedViewCatalogItem.from_parent(parent=parent, label=label)
+        return TableCatalogItem.from_parent(parent=parent, label=label)
 
     def get_completions(self) -> list[HarlequinCompletion]:
         conn: Connection = self.pool.getconn()
@@ -497,6 +731,7 @@ class HarlequinPostgresConnection(HarlequinConnection):
 class HarlequinPostgresAdapter(HarlequinAdapter):
     ADAPTER_OPTIONS = POSTGRES_OPTIONS
     IMPLEMENTS_CANCEL = True
+    IMPLEMENTS_CATALOG_SEARCH = True
     IMPLEMENTS_READ_ONLY = True
 
     def __init__(

--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -24,6 +24,7 @@ from psycopg_pool import ConnectionPool
 from textual_fastdatatable.backend import AutoBackendType
 
 from harlequin_postgres.catalog import (
+    MATERIALIZED_VIEW,
     ColumnCatalogItem,
     DatabaseCatalogItem,
     ForeignCatalogItem,
@@ -40,9 +41,6 @@ from harlequin_postgres.loaders import register_inf_loaders
 
 _LIKE_ESCAPE = "\\"
 """What escapes a LIKE metacharacter in a term the caller typed."""
-
-_MATERIALIZED_VIEW = "MATERIALIZED VIEW"
-"""A relation type for matviews, which information_schema.tables does not have."""
 
 
 def _user_schemas(column: str) -> str:
@@ -97,7 +95,7 @@ where
 _SEARCH_MATERIALIZED_VIEWS = f"""
 select
     current_database()::text, m.schemaname::text, m.matviewname::text,
-    '{_MATERIALIZED_VIEW}'::text, null::text, null::text
+    '{MATERIALIZED_VIEW}'::text, null::text, null::text
 from pg_matviews m
 where
     {_user_schemas("m.schemaname")}
@@ -123,7 +121,7 @@ where
 _SEARCH_MATERIALIZED_VIEW_COLUMNS = f"""
 select
     current_database()::text, s.nspname::text, t.relname::text,
-    '{_MATERIALIZED_VIEW}'::text, a.attname::text,
+    '{MATERIALIZED_VIEW}'::text, a.attname::text,
     pg_catalog.format_type(a.atttypid, a.atttypmod)::text
 from pg_attribute a
 join pg_class t on a.attrelid = t.oid
@@ -443,6 +441,7 @@ class HarlequinPostgresConnection(HarlequinConnection):
                         parent=relation_item,
                         label=column,
                         type_label=self._short_column_type(column_type or ""),
+                        type_name=column_type,
                     ),
                     parents=(catalog, schema, relation),
                 )
@@ -455,14 +454,24 @@ class HarlequinPostgresConnection(HarlequinConnection):
     ) -> RelationCatalogItem:
         """A relation of the class `fetch_children()` would have built for it."""
         if relation_type == "VIEW":
-            return ViewCatalogItem.from_parent(parent=parent, label=label)
+            return ViewCatalogItem.from_parent(
+                parent=parent, label=label, type_name=relation_type
+            )
         if relation_type == "LOCAL TEMPORARY":
-            return TempTableCatalogItem.from_parent(parent=parent, label=label)
+            return TempTableCatalogItem.from_parent(
+                parent=parent, label=label, type_name=relation_type
+            )
         if relation_type == "FOREIGN":
-            return ForeignCatalogItem.from_parent(parent=parent, label=label)
-        if relation_type == _MATERIALIZED_VIEW:
-            return MaterializedViewCatalogItem.from_parent(parent=parent, label=label)
-        return TableCatalogItem.from_parent(parent=parent, label=label)
+            return ForeignCatalogItem.from_parent(
+                parent=parent, label=label, type_name=relation_type
+            )
+        if relation_type == MATERIALIZED_VIEW:
+            return MaterializedViewCatalogItem.from_parent(
+                parent=parent, label=label, type_name=relation_type
+            )
+        return TableCatalogItem.from_parent(
+            parent=parent, label=label, type_name=relation_type
+        )
 
     def get_completions(self) -> list[HarlequinCompletion]:
         conn: Connection = self.pool.getconn()

--- a/src/harlequin_postgres/catalog.py
+++ b/src/harlequin_postgres/catalog.py
@@ -25,6 +25,13 @@ from harlequin_postgres.interactions import (
 if TYPE_CHECKING:
     from harlequin_postgres.adapter import HarlequinPostgresConnection
 
+MATERIALIZED_VIEW = "MATERIALIZED VIEW"
+"""What Postgres calls a matview, which information_schema.tables does not have.
+
+`table_type` names every other kind of relation, so this stands in for it as a
+matview's `type_name`.
+"""
+
 
 @dataclass
 class ColumnCatalogItem(InteractiveCatalogItem["HarlequinPostgresConnection"]):
@@ -36,6 +43,7 @@ class ColumnCatalogItem(InteractiveCatalogItem["HarlequinPostgresConnection"]):
         parent: "RelationCatalogItem",
         label: str,
         type_label: str,
+        type_name: str | None = None,
     ) -> "ColumnCatalogItem":
         column_qualified_identifier = f'{parent.qualified_identifier}."{label}"'
         column_query_name = f'"{label}"'
@@ -44,6 +52,7 @@ class ColumnCatalogItem(InteractiveCatalogItem["HarlequinPostgresConnection"]):
             query_name=column_query_name,
             label=label,
             type_label=type_label,
+            type_name=type_name,
             connection=parent.connection,
             parent=parent,
             loaded=True,
@@ -70,6 +79,7 @@ class RelationCatalogItem(InteractiveCatalogItem["HarlequinPostgresConnection"])
                 parent=self,
                 label=column_name,
                 type_label=self.connection._short_column_type(column_type),
+                type_name=column_type,
             )
             for column_name, column_type in result
         ]
@@ -86,6 +96,7 @@ class ViewCatalogItem(RelationCatalogItem):
         cls,
         parent: "SchemaCatalogItem",
         label: str,
+        type_name: str | None = "VIEW",
     ) -> "ViewCatalogItem":
         relation_query_name = f'"{parent.label}"."{label}"'
         relation_qualified_identifier = f'{parent.qualified_identifier}."{label}"'
@@ -94,6 +105,7 @@ class ViewCatalogItem(RelationCatalogItem):
             query_name=relation_query_name,
             label=label,
             type_label="v",
+            type_name=type_name,
             connection=parent.connection,
             parent=parent,
         )
@@ -111,6 +123,7 @@ class TableCatalogItem(RelationCatalogItem):
         cls,
         parent: "SchemaCatalogItem",
         label: str,
+        type_name: str | None = "BASE TABLE",
     ) -> "TableCatalogItem":
         relation_query_name = f'"{parent.label}"."{label}"'
         relation_qualified_identifier = f'{parent.qualified_identifier}."{label}"'
@@ -119,6 +132,7 @@ class TableCatalogItem(RelationCatalogItem):
             query_name=relation_query_name,
             label=label,
             type_label="t",
+            type_name=type_name,
             connection=parent.connection,
             parent=parent,
         )
@@ -130,6 +144,7 @@ class TempTableCatalogItem(TableCatalogItem):
         cls,
         parent: "SchemaCatalogItem",
         label: str,
+        type_name: str | None = "LOCAL TEMPORARY",
     ) -> "TempTableCatalogItem":
         relation_query_name = f'"{parent.label}"."{label}"'
         relation_qualified_identifier = f'{parent.qualified_identifier}."{label}"'
@@ -138,6 +153,7 @@ class TempTableCatalogItem(TableCatalogItem):
             query_name=relation_query_name,
             label=label,
             type_label="tmp",
+            type_name=type_name,
             connection=parent.connection,
             parent=parent,
         )
@@ -153,6 +169,7 @@ class ForeignCatalogItem(TableCatalogItem):
         cls,
         parent: "SchemaCatalogItem",
         label: str,
+        type_name: str | None = "FOREIGN",
     ) -> "ForeignCatalogItem":
         relation_query_name = f'"{parent.label}"."{label}"'
         relation_qualified_identifier = f'{parent.qualified_identifier}."{label}"'
@@ -161,6 +178,7 @@ class ForeignCatalogItem(TableCatalogItem):
             query_name=relation_query_name,
             label=label,
             type_label="f",
+            type_name=type_name,
             connection=parent.connection,
             parent=parent,
         )
@@ -172,6 +190,7 @@ class MaterializedViewCatalogItem(RelationCatalogItem):
         cls,
         parent: "SchemaCatalogItem",
         label: str,
+        type_name: str | None = MATERIALIZED_VIEW,
     ) -> "MaterializedViewCatalogItem":
         relation_query_name = f'"{parent.label}"."{label}"'
         relation_qualified_identifier = f'{parent.qualified_identifier}."{label}"'
@@ -180,6 +199,7 @@ class MaterializedViewCatalogItem(RelationCatalogItem):
             query_name=relation_query_name,
             label=label,
             type_label="mv",
+            type_name=type_name,
             connection=parent.connection,
             parent=parent,
         )
@@ -193,6 +213,7 @@ class MaterializedViewCatalogItem(RelationCatalogItem):
                 parent=self,
                 label=column_name,
                 type_label=self.connection._short_column_type(column_type),
+                type_name=column_type,
             )
             for column_name, column_type in result
         ]
@@ -230,11 +251,14 @@ class SchemaCatalogItem(InteractiveCatalogItem["HarlequinPostgresConnection"]):
         children: list[RelationCatalogItem] = []
         result = self.connection._get_relations(self.parent.label, self.label)
         for table_label, table_type in result:
+            # the relation's own class carries its type_label; table_type is how
+            # this database spells the same thing, so it is passed through
             if table_type == "VIEW":
                 children.append(
                     ViewCatalogItem.from_parent(
                         parent=self,
                         label=table_label,
+                        type_name=table_type,
                     )
                 )
             elif table_type == "LOCAL TEMPORARY":
@@ -242,6 +266,7 @@ class SchemaCatalogItem(InteractiveCatalogItem["HarlequinPostgresConnection"]):
                     TempTableCatalogItem.from_parent(
                         parent=self,
                         label=table_label,
+                        type_name=table_type,
                     )
                 )
             elif table_type == "FOREIGN":
@@ -249,6 +274,7 @@ class SchemaCatalogItem(InteractiveCatalogItem["HarlequinPostgresConnection"]):
                     ForeignCatalogItem.from_parent(
                         parent=self,
                         label=table_label,
+                        type_name=table_type,
                     )
                 )
             else:
@@ -256,6 +282,7 @@ class SchemaCatalogItem(InteractiveCatalogItem["HarlequinPostgresConnection"]):
                     TableCatalogItem.from_parent(
                         parent=self,
                         label=table_label,
+                        type_name=table_type,
                     )
                 )
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,7 +1,11 @@
 import pytest
-from harlequin.catalog import InteractiveCatalogItem
+from harlequin.catalog import CatalogSearchResult, InteractiveCatalogItem
+from harlequin.exception import HarlequinQueryError
 
-from harlequin_postgres.adapter import HarlequinPostgresConnection
+from harlequin_postgres.adapter import (
+    HarlequinPostgresAdapter,
+    HarlequinPostgresConnection,
+)
 from harlequin_postgres.catalog import (
     ColumnCatalogItem,
     DatabaseCatalogItem,
@@ -111,3 +115,234 @@ def test_catalog(connection_with_objects: HarlequinPostgresConnection) -> None:
     foo_mv_cols = foo_mv_item.fetch_children()
     assert foo_mv_cols
     assert all(isinstance(item, ColumnCatalogItem) for item in foo_mv_cols)
+
+
+@pytest.fixture
+def connection_for_search(
+    connection_with_objects: HarlequinPostgresConnection,
+) -> HarlequinPostgresConnection:
+    conn = connection_with_objects
+    conn.execute("create table one.orders as select 1 as customer_id, 2 as amount")
+    # a schema, a relation, and a column that all match the same term, to check
+    # that a search reports a parent before the items under it
+    conn.execute("create schema five")
+    conn.execute("create table five.five_a as select 1 as five_col")
+    # names holding LIKE metacharacters, which a term must not be able to use
+    conn.execute('create table one."a_b" as select 1 as a')
+    conn.execute('create table one."axb" as select 1 as a')
+    conn.execute('create table one."pct%tbl" as select 1 as a')
+    # the original connection fixture will clean this up.
+    return conn
+
+
+def _labeled(results: list[CatalogSearchResult], label: str) -> CatalogSearchResult:
+    [result] = [r for r in results if r.item.label == label]
+    return result
+
+
+def test_implements_catalog_search() -> None:
+    assert HarlequinPostgresAdapter.IMPLEMENTS_CATALOG_SEARCH is True
+
+
+def test_search_catalog_relations(
+    connection_for_search: HarlequinPostgresConnection,
+) -> None:
+    conn = connection_for_search
+
+    results = conn.search_catalog("foo", kind="relations")
+
+    assert [(r.item.label, r.parents) for r in results] == [
+        ("foo", ("test", "four")),
+        ("foo", ("test", "one")),
+    ]
+    matview_result, table_result = results
+    assert isinstance(matview_result.item, MaterializedViewCatalogItem)
+    assert isinstance(table_result.item, TableCatalogItem)
+    # a relation is built by the class fetch_children() would have used for it,
+    # so its query name is the one --catalog shows for the same object
+    assert table_result.item.query_name == '"one"."foo"'
+    assert table_result.item.type_label == "t"
+    assert matview_result.item.type_label == "mv"
+
+
+def test_search_catalog_relations_finds_views(
+    connection_for_search: HarlequinPostgresConnection,
+) -> None:
+    results = connection_for_search.search_catalog("qux", kind="relations")
+
+    [result] = results
+    assert isinstance(result.item, ViewCatalogItem)
+    assert result.item.type_label == "v"
+    assert result.parents == ("test", "two")
+
+
+def test_search_catalog_columns(
+    connection_for_search: HarlequinPostgresConnection,
+) -> None:
+    results = connection_for_search.search_catalog("customer", kind="columns")
+
+    [result] = results
+    assert isinstance(result.item, ColumnCatalogItem)
+    assert result.item.label == "customer_id"
+    assert result.parents == ("test", "one", "orders")
+    assert result.item.query_name == '"customer_id"'
+    assert result.item.type_label == "#"
+
+
+def test_search_catalog_columns_finds_matview_columns(
+    connection_for_search: HarlequinPostgresConnection,
+) -> None:
+    # four.foo is a materialized view, which information_schema does not have
+    results = connection_for_search.search_catalog("b", kind="columns")
+
+    matview_results = [r for r in results if r.parents == ("test", "four", "foo")]
+    [result] = matview_results
+    assert isinstance(result.item, ColumnCatalogItem)
+    assert result.item.label == "b"
+    assert result.item.type_label == "s"
+
+
+def test_search_catalog_kinds_are_scoped(
+    connection_for_search: HarlequinPostgresConnection,
+) -> None:
+    conn = connection_for_search
+
+    relations = conn.search_catalog("five", kind="relations")
+    assert [r.item.label for r in relations] == ["five_a"]
+
+    columns = conn.search_catalog("five", kind="columns")
+    assert [r.item.label for r in columns] == ["five_col"]
+
+
+def test_search_catalog_all_returns_every_level(
+    connection_for_search: HarlequinPostgresConnection,
+) -> None:
+    results = connection_for_search.search_catalog("five", kind="all")
+
+    # a parent arrives before the items under it
+    assert [(r.item.label, r.parents) for r in results] == [
+        ("five", ("test",)),
+        ("five_a", ("test", "five")),
+        ("five_col", ("test", "five", "five_a")),
+    ]
+    schema_result, relation_result, column_result = results
+    assert isinstance(schema_result.item, SchemaCatalogItem)
+    assert isinstance(relation_result.item, TableCatalogItem)
+    assert isinstance(column_result.item, ColumnCatalogItem)
+
+
+def test_search_catalog_matches_databases_by_name(
+    connection_for_search: HarlequinPostgresConnection,
+) -> None:
+    conn = connection_for_search
+
+    results = conn.search_catalog("postgres", kind="all")
+
+    # the pool is bound to one database, but the others can still be matched
+    # by name, which is all the catalog's top level shows for them
+    result = _labeled(results, "postgres")
+    assert isinstance(result.item, DatabaseCatalogItem)
+    assert result.parents == ()
+    assert result.item.query_name == '"postgres"'
+
+    # a database is not a relation, so the narrower kinds do not report it
+    assert not conn.search_catalog("postgres", kind="relations")
+
+
+def test_search_catalog_is_case_insensitive(
+    connection_for_search: HarlequinPostgresConnection,
+) -> None:
+    conn = connection_for_search
+
+    assert [(r.item.label, r.parents) for r in conn.search_catalog("FOO")] == [
+        (r.item.label, r.parents) for r in conn.search_catalog("foo")
+    ]
+
+
+def test_search_catalog_matches_a_substring(
+    connection_for_search: HarlequinPostgresConnection,
+) -> None:
+    results = connection_for_search.search_catalog("rder", kind="relations")
+
+    assert [r.item.label for r in results] == ["orders"]
+
+
+@pytest.mark.parametrize(
+    "term,expected",
+    [
+        ("a_b", ["a_b"]),
+        ("%tbl", ["pct%tbl"]),
+        ("pct%", ["pct%tbl"]),
+    ],
+)
+def test_search_catalog_escapes_like_metacharacters(
+    connection_for_search: HarlequinPostgresConnection,
+    term: str,
+    expected: list[str],
+) -> None:
+    results = connection_for_search.search_catalog(term, kind="relations")
+
+    assert [r.item.label for r in results] == expected
+
+
+def test_search_catalog_excludes_system_schemas(
+    connection_for_search: HarlequinPostgresConnection,
+) -> None:
+    conn = connection_for_search
+
+    # information_schema.columns and pg_catalog.pg_statistic exist, but the
+    # catalog tree does not show them, so a search must not report them either
+    assert not conn.search_catalog("information_schema", kind="all")
+    assert not conn.search_catalog("pg_statistic", kind="relations")
+
+
+def test_search_catalog_without_a_match_is_empty(
+    connection_for_search: HarlequinPostgresConnection,
+) -> None:
+    assert connection_for_search.search_catalog("no-such-object") == []
+
+
+def test_search_catalog_raises_query_error(
+    connection_for_search: HarlequinPostgresConnection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from harlequin_postgres import adapter
+
+    monkeypatch.setitem(adapter._SEARCH_SQL, "all", "select not_a_column")
+
+    with pytest.raises(HarlequinQueryError):
+        connection_for_search.search_catalog("foo")
+
+    # the connection went back to the pool, so the next search still works
+    monkeypatch.undo()
+    assert connection_for_search.search_catalog("foo")
+
+
+def test_search_catalog_items_match_fetch_children(
+    connection_for_search: HarlequinPostgresConnection,
+) -> None:
+    conn = connection_for_search
+
+    [db_item] = [
+        i
+        for i in conn.get_catalog().items
+        if isinstance(i, DatabaseCatalogItem) and i.label == "test"
+    ]
+    [schema_item] = [i for i in db_item.fetch_children() if i.label == "one"]
+    [walked_relation] = [i for i in schema_item.fetch_children() if i.label == "orders"]
+    [walked_column] = [
+        i for i in walked_relation.fetch_children() if i.label == "customer_id"
+    ]
+
+    [searched_relation] = conn.search_catalog("orders", kind="relations")
+    [searched_column] = conn.search_catalog("customer_id", kind="columns")
+
+    for walked, searched in (
+        (walked_relation, searched_relation.item),
+        (walked_column, searched_column.item),
+    ):
+        assert type(searched) is type(walked)
+        assert searched.label == walked.label
+        assert searched.query_name == walked.query_name
+        assert searched.qualified_identifier == walked.qualified_identifier
+        assert searched.type_label == walked.type_label

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -117,6 +117,45 @@ def test_catalog(connection_with_objects: HarlequinPostgresConnection) -> None:
     assert all(isinstance(item, ColumnCatalogItem) for item in foo_mv_cols)
 
 
+def test_catalog_items_carry_type_names(
+    connection_with_objects: HarlequinPostgresConnection,
+) -> None:
+    """Every item the catalog walk builds names its full type, not just a label."""
+    conn = connection_with_objects
+
+    [db_item] = [
+        i
+        for i in conn.get_catalog().items
+        if isinstance(i, DatabaseCatalogItem) and i.label == "test"
+    ]
+    schema_items = db_item.fetch_children()
+    [schema_one_item] = [i for i in schema_items if i.label == "one"]
+    [schema_two_item] = [i for i in schema_items if i.label == "two"]
+    [schema_four_item] = [i for i in schema_items if i.label == "four"]
+
+    [table_item] = [i for i in schema_one_item.fetch_children() if i.label == "foo"]
+    [view_item] = [i for i in schema_two_item.fetch_children() if i.label == "qux"]
+    [matview_item] = [i for i in schema_four_item.fetch_children() if i.label == "foo"]
+
+    assert table_item.type_name == "BASE TABLE"
+    assert view_item.type_name == "VIEW"
+    assert matview_item.type_name == "MATERIALIZED VIEW"
+
+    # a column's type_name is the full type its type_label is shortened from
+    assert [
+        (i.label, i.type_label, i.type_name) for i in table_item.fetch_children()
+    ] == [
+        ("a", "#", "integer"),
+        ("b", "s", "text"),
+    ]
+    assert [
+        (i.label, i.type_label, i.type_name) for i in matview_item.fetch_children()
+    ] == [
+        ("a", "#", "integer"),
+        ("b", "s", "text"),
+    ]
+
+
 @pytest.fixture
 def connection_for_search(
     connection_with_objects: HarlequinPostgresConnection,
@@ -161,8 +200,14 @@ def test_search_catalog_relations(
     # a relation is built by the class fetch_children() would have used for it,
     # so its query name is the one --catalog shows for the same object
     assert table_result.item.query_name == '"one"."foo"'
-    assert table_result.item.type_label == "t"
-    assert matview_result.item.type_label == "mv"
+    assert (table_result.item.type_label, table_result.item.type_name) == (
+        "t",
+        "BASE TABLE",
+    )
+    assert (matview_result.item.type_label, matview_result.item.type_name) == (
+        "mv",
+        "MATERIALIZED VIEW",
+    )
 
 
 def test_search_catalog_relations_finds_views(
@@ -172,7 +217,7 @@ def test_search_catalog_relations_finds_views(
 
     [result] = results
     assert isinstance(result.item, ViewCatalogItem)
-    assert result.item.type_label == "v"
+    assert (result.item.type_label, result.item.type_name) == ("v", "VIEW")
     assert result.parents == ("test", "two")
 
 
@@ -186,7 +231,8 @@ def test_search_catalog_columns(
     assert result.item.label == "customer_id"
     assert result.parents == ("test", "one", "orders")
     assert result.item.query_name == '"customer_id"'
-    assert result.item.type_label == "#"
+    # type_name is the full type the label is shortened from
+    assert (result.item.type_label, result.item.type_name) == ("#", "integer")
 
 
 def test_search_catalog_columns_finds_matview_columns(
@@ -199,7 +245,7 @@ def test_search_catalog_columns_finds_matview_columns(
     [result] = matview_results
     assert isinstance(result.item, ColumnCatalogItem)
     assert result.item.label == "b"
-    assert result.item.type_label == "s"
+    assert (result.item.type_label, result.item.type_name) == ("s", "text")
 
 
 def test_search_catalog_kinds_are_scoped(
@@ -346,3 +392,4 @@ def test_search_catalog_items_match_fetch_children(
         assert searched.query_name == walked.query_name
         assert searched.qualified_identifier == walked.qualified_identifier
         assert searched.type_label == walked.type_label
+        assert searched.type_name == walked.type_name

--- a/uv.lock
+++ b/uv.lock
@@ -20,14 +20,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -88,43 +88,41 @@ wheels = [
 
 [[package]]
 name = "duckdb"
-version = "1.5.0.dev86"
+version = "1.6.0.dev365"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14'",
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/02/4f/35f76cea0d10d407bd2e9f14b1fd355c5bb2278b7705196f01f8dd0039cc/duckdb-1.5.0.dev86.tar.gz", hash = "sha256:5bfeb0756b158b1f7cf06dcb2f2cb1d02107c3fbefd7e61793ae4c3c70024b2f", size = 18505614, upload-time = "2025-10-29T07:31:51.851Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/1e/c041fb7ca169311757221e9ef0d9ab7af6d221df4fea820a150254adc1e0/duckdb-1.6.0.dev365.tar.gz", hash = "sha256:18a84444a693b3213238a210fae2d49de15d416456db6f484e17809ce01db57d", size = 15517383, upload-time = "2026-08-20T16:27:37.39Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/88/9d60c0733421893480f760ea846b033484220b42e5dc69bc525f308ca388/duckdb-1.5.0.dev86-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ebc9d8adeb84c35d0e321cad1dcb9319f3323cb6638c678bfbbe639817773c93", size = 28982105, upload-time = "2025-10-29T07:30:24.958Z" },
-    { url = "https://files.pythonhosted.org/packages/03/d9/07ecf3c605d4ab9ed5bc1258aed9a8f487f7bd590196e40cad5fca86ba21/duckdb-1.5.0.dev86-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:856aebc2bda1fdeb8bc949535c0a78185e8e6d1ae6d9198d2a7bd9321afb4b47", size = 16144760, upload-time = "2025-10-29T07:30:27.631Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/6a/0a843c50ad6425d07be37bd3894055167cf0b8df3ff077401e152a506ae8/duckdb-1.5.0.dev86-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:960f19c4744013de12878adf8e26f546cd084716ef9c5969b0f3645194ab2d96", size = 13709315, upload-time = "2025-10-29T07:30:30.358Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/94/13bb19f94775b12512b32ce3f4f6e984d878dc7cbe5f55d4f1f8edab5859/duckdb-1.5.0.dev86-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d11e3ec37259b379f71e9b21372406258f39613b39b35aa0b823aeb96cf037de", size = 18517034, upload-time = "2025-10-29T07:30:32.839Z" },
-    { url = "https://files.pythonhosted.org/packages/94/b9/52243e3842e879cc10d8658086a8923bdd1ff0593d1f498c21136476ae15/duckdb-1.5.0.dev86-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a7ac2f79bf33626bb7a7745d1ee75eabcfa75be1c19514fdbf2b3d16e8f1f11", size = 20499998, upload-time = "2025-10-29T07:30:35.024Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b1/c85d14af54de0a2c8a000d87b2e7ff29bbdd9de8d9fa361b11b2ede01b37/duckdb-1.5.0.dev86-cp310-cp310-win_amd64.whl", hash = "sha256:0ce2685d334ecac9ad3165c031ea8295aaefa044ab845d13010d3ca179ef8d18", size = 12346756, upload-time = "2025-10-29T07:30:37.508Z" },
-    { url = "https://files.pythonhosted.org/packages/19/f8/b766c0b940e766d4511bb5137a17f4aecafff7dc5f259d34b83fdd1e4f60/duckdb-1.5.0.dev86-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ed771fe5e9ad3ce219fae823e14c42bf80d192e1294e90d5a45ef8a6cd74136e", size = 28983520, upload-time = "2025-10-29T07:30:39.95Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/a3/22a989bf784e7df53ff4f2d95f1a784c8c1c5fe1ee6310e62aef74e05676/duckdb-1.5.0.dev86-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ca164b436b6778fee9e1ad6313adca12789693648277333e073c2f51e2d7dc9e", size = 16146467, upload-time = "2025-10-29T07:30:42.626Z" },
-    { url = "https://files.pythonhosted.org/packages/25/b6/70e7f64b6b31b8e0e44fea37ef9fb2222d3b84e3829b8edca5f04a7c6942/duckdb-1.5.0.dev86-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93031e0aa08be9af176d20fbba5a2d1d6e267bdcaba08c156ed032181dffbfd0", size = 13711152, upload-time = "2025-10-29T07:30:45.195Z" },
-    { url = "https://files.pythonhosted.org/packages/30/2d/6525daa5c11ab4fa433d9ea03b5c0bd54eb59dd7a518c96a10b880b99d0b/duckdb-1.5.0.dev86-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3b9484d9011e94d3dfc2f5a22655191f3d60e078f10e4d4f18dee6ba337884df", size = 18515430, upload-time = "2025-10-29T07:30:47.4Z" },
-    { url = "https://files.pythonhosted.org/packages/93/75/2f593d75b439f2d2c8538eacdd963c51fdde94498334445bc1c270af3497/duckdb-1.5.0.dev86-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10f0974cf87fefe9f50c30a5e3ac2292ec89f93c9d79bd4ab49ee4c20afce4ae", size = 20505247, upload-time = "2025-10-29T07:30:49.923Z" },
-    { url = "https://files.pythonhosted.org/packages/18/98/c1bbbe8090573e9f03b31207afd2eb920301431c92b109e3698199792496/duckdb-1.5.0.dev86-cp311-cp311-win_amd64.whl", hash = "sha256:39de0e49655acdeaf07051e5d8ed8afdff104eb05b8a2ddaf4a246d8aec37471", size = 12348611, upload-time = "2025-10-29T07:30:52.106Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/0c/3832b32f0fc0ad04f0f11f8d19a8c3fbe3987c0eec701742e0274bd47749/duckdb-1.5.0.dev86-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9fc8ad6ac46274bd013fc19173f591d4824a007eb3f8e39d430681b25e061d6d", size = 28992222, upload-time = "2025-10-29T07:30:54.954Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/ff/d3a7c5cb9fb87ecd6a10ef40511ab5033910e89e866ad6e5a8b9a9095e89/duckdb-1.5.0.dev86-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:52537dca61ce2517f1e34a6dba0292ce2ad349cfc76bf53cd040408d5e272350", size = 16148661, upload-time = "2025-10-29T07:30:57.497Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/99/41a7b814dd62136fa79498b069dc3682739b952d3d39a1d04074cde922fc/duckdb-1.5.0.dev86-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bca3f1d3ca4119a5bb9536eba17d527d01b204d0602cf73e776796da5c367256", size = 13718905, upload-time = "2025-10-29T07:30:59.596Z" },
-    { url = "https://files.pythonhosted.org/packages/09/06/13a327811d8997030d559108804e10eca801fc502e7e2ddab3fa39cc195d/duckdb-1.5.0.dev86-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f060ca56a9ba9b6cad7835d93b98e4706a8ffc90450a84620f115ba60e9ddadb", size = 18528288, upload-time = "2025-10-29T07:31:01.834Z" },
-    { url = "https://files.pythonhosted.org/packages/79/6a/28389f3544d387dbc281bad73c36a86869e5ce0e3ee34b04b719aaf2fcc2/duckdb-1.5.0.dev86-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9af0fe6aaf55d0d4552776a27b907224c22820db563ac24ca7be4a7e3ebcd84b", size = 20528050, upload-time = "2025-10-29T07:31:04.041Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/bc/5494742ed74d2dcef7666cf191d95e6e083007c9709232332f82ab6d2e7f/duckdb-1.5.0.dev86-cp312-cp312-win_amd64.whl", hash = "sha256:c26c71ab1165642bad0d531b95b1afecc3239bd7cf6f586c9cb0bccce8ab92d9", size = 12353388, upload-time = "2025-10-29T07:31:06.239Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b3/233fd2eb65b9ad0158dc8b7c1a48733ebf87d0f2f4f7333ac3c393487b8c/duckdb-1.5.0.dev86-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8e611d88e87ca4c2ed8f5c2f80585e30da6d6925dc537b4e4015798c41f11eef", size = 28991657, upload-time = "2025-10-29T07:31:08.445Z" },
-    { url = "https://files.pythonhosted.org/packages/14/b5/10d5ca714058f7d20207bcdd2fb5f436398f437eec898afc3b70e05c9544/duckdb-1.5.0.dev86-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:09869da0dc9e20220daceb6574c3d488480c8290e2f882ca0327e5384d16da18", size = 16148411, upload-time = "2025-10-29T07:31:11.118Z" },
-    { url = "https://files.pythonhosted.org/packages/67/64/910208203c91a4601384796796b6265d66b255633d3f2864ba1dee8ed817/duckdb-1.5.0.dev86-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:50f563db237f11dcc2811c1ef7f1ac3da53cd642913a30543676c2ff3aa0709b", size = 13718542, upload-time = "2025-10-29T07:31:13.383Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/93/4f2e3f3c301e7b17a2af109a1275aa0dcfb511b9d5f84a4a25c1be914ee4/duckdb-1.5.0.dev86-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae2d9edce530997010227f9ccb8e282509b820bcf36cdb6663a91526b30081bb", size = 18531501, upload-time = "2025-10-29T07:31:15.818Z" },
-    { url = "https://files.pythonhosted.org/packages/55/93/9e4353b30b6524f7330d47ba9fe16b8af069efb165af0f721b494a210113/duckdb-1.5.0.dev86-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:07719c7216b7744284f64c484de44b4fe899424a5f42977a973a301b4870f408", size = 20530074, upload-time = "2025-10-29T07:31:18.442Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/19/f97cc6495f22a9eb247745e5c4e594cd2693b184d33a8f2e9bf6c712030a/duckdb-1.5.0.dev86-cp313-cp313-win_amd64.whl", hash = "sha256:0953dd910affbaec10aeb631461d024de9a98e01a43ca05e9c1f6d1b5a43a440", size = 12353407, upload-time = "2025-10-29T07:31:20.492Z" },
-    { url = "https://files.pythonhosted.org/packages/73/09/fc6db88331f1ddb3d6851ec93657dbc401a35c69fafde0a45fca1a2dc066/duckdb-1.5.0.dev86-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:5bff4fa523e7920b5e8b0a7211c543ff184d716851b4a9601aff3d78260178ef", size = 29006310, upload-time = "2025-10-29T07:31:22.845Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/d8/66c1ba0bad8df7ac41c27078f2cdbf5ab61b0df8236ecf8566883806c56a/duckdb-1.5.0.dev86-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:12efcc18b04ce62ffb182102339569e5e47d0bf15f79f5bab1ec46a466e67027", size = 16150704, upload-time = "2025-10-29T07:31:25.319Z" },
-    { url = "https://files.pythonhosted.org/packages/76/47/6509f1ed115dd34443f5f49b4451679cd6e5fed52c618c411f21778a1e51/duckdb-1.5.0.dev86-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9b97cd286f4511329cda280aeb2c1b2ea856c4d07e53c84eec1d60603a099dcf", size = 13730268, upload-time = "2025-10-29T07:31:27.832Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/a7/3e77c78384234db3ea7d30954ad9132a97be83424b809d9815a2a987c6c0/duckdb-1.5.0.dev86-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cc8aa2fc9000a2f4a69b98e87c99191d2536e4b25ea78ea89db3e4e3383d794d", size = 18538173, upload-time = "2025-10-29T07:31:30.011Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/61/e377971ade08e86c1c0f5657433cc4918a05cde5be137305393ad3c22195/duckdb-1.5.0.dev86-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2d7f86592d9c356418315b91110951f6fe911043139ec4498cb5712014cbb554", size = 20533062, upload-time = "2025-10-29T07:31:32.617Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/a0/c052a6e9460292d69a22ec330b8afd577baaf06614027d3f656007f27b34/duckdb-1.5.0.dev86-cp314-cp314-win_amd64.whl", hash = "sha256:3f9e2d9efb0f72324da499c28f5b27454c0117e7212f1ee8efac2a029af4d9f7", size = 12856703, upload-time = "2025-10-29T07:31:34.817Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ed/d24996fc0cb278eafd593e4246f74e314092fd1b5b0bfe5cf636f657698c/duckdb-1.6.0.dev365-cp311-cp311-macosx_10_14_universal2.whl", hash = "sha256:0f4add8e49ac541d158c9a4f96afdb516c6f6667ccb349f2f73d787112871df0", size = 34201194, upload-time = "2026-08-20T16:25:41.825Z" },
+    { url = "https://files.pythonhosted.org/packages/89/fb/5854111034987e45178020f6292f6ed4de5145f09b5a44c9cb25032941c8/duckdb-1.6.0.dev365-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:97f2f320369196f89122adcf5992dbdfe3b2af2faef90b9313e4c8d7cb530575", size = 18169837, upload-time = "2026-08-20T16:25:45.731Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/74/84082aaf8fa343855b4f481440d32102f18967d654981570821d04481be6/duckdb-1.6.0.dev365-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:34b396b466fcda9934c9c750829d4597d03fc9c1c38fe79c2b336041c2275874", size = 16158730, upload-time = "2026-08-20T16:25:49.187Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/54/c70f16eb2cc7593528f7d28505cc313e0d149ad418a34fe0a1bd9401c5d3/duckdb-1.6.0.dev365-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e4b59682edf98f6ce75bdfbc66e267fd7bb0e7e276a08ef5a249837b51bde6c", size = 20147745, upload-time = "2026-08-20T16:25:52.565Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/6f/896de7be31376a9994b46273ccb5b987410eecbd9580d9fafe9511eca913/duckdb-1.6.0.dev365-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb3732d7a8ca1f4383459a518e571a6e9a66cba87b38439f7c987e66b2d7bcac", size = 22685006, upload-time = "2026-08-20T16:25:56.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/f3/1a5826584763e52d74e380531bcb01cf9d36317b5a4703741e7364430893/duckdb-1.6.0.dev365-cp311-cp311-win_amd64.whl", hash = "sha256:fd035dc5496842723bb83ecf23059dfd0ed649e691d62ee54f26dcc56fe995a6", size = 13697227, upload-time = "2026-08-20T16:26:00.064Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e3/f01fedf9248a03a52db58321d3e174301eaa4e12d217d7f106d3cfd2f23a/duckdb-1.6.0.dev365-cp311-cp311-win_arm64.whl", hash = "sha256:883af9b0652e80b3d7a8ca42181cc9ed69b3be1e92bbb3d3f08de9da69e32343", size = 14207114, upload-time = "2026-08-20T16:26:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/52/5c669ea7ec609c2c6213152cc507c4551d597b6f954692158f1034968c1d/duckdb-1.6.0.dev365-cp312-cp312-macosx_10_14_universal2.whl", hash = "sha256:63ddc87aae18cd785740f9873c2bce62feb0ea9bbcb89f8a7dc98e64cbe8c812", size = 34199583, upload-time = "2026-08-20T16:26:08.998Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0a/e240dc09a4cf39379b1e214e1aecf56ecf0d29a2d12bdb427ecebc7c3525/duckdb-1.6.0.dev365-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:69e5526b2407261fea891e25531b4211314fc78d44d0788c55455090c1c3152b", size = 18170809, upload-time = "2026-08-20T16:26:13.499Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/90/bb189d9c69c1b87f1a4b935b15b2ed9bcec060ebf7cf395a9b897199fce8/duckdb-1.6.0.dev365-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8a71f74685b26985bc2b32bd6b87ada92b1511d405e3320c1f591f8268ea9ee2", size = 16157927, upload-time = "2026-08-20T16:26:17.497Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ac/19e7ac30109b9ec31763bb89161b118516a0154835facc77962dd2f61891/duckdb-1.6.0.dev365-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f81678630d7a1820e77d067f6374c3a2bdfb0bbccf5d8df91c6a19128c16825d", size = 20147347, upload-time = "2026-08-20T16:26:23.159Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c0/931db4c54f674ea4913b83742b3c36be8c80c4c85ca64b2efe2a4c2ab2d0/duckdb-1.6.0.dev365-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c8405a608014c42369750e9c329ef2de0ecc29a71d222e94bad133c8fc537417", size = 22687542, upload-time = "2026-08-20T16:26:27.755Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/a3/31ae246043b325e2dd7a2f339309b339fcbe59b0bf6a1d8c09770d9c60d6/duckdb-1.6.0.dev365-cp312-cp312-win_amd64.whl", hash = "sha256:fe54df4f5778a1e243ffa54ae0429d8b73f1836e582f0ad581f914f126f59743", size = 13698243, upload-time = "2026-08-20T16:26:33.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/1edc7a770fd37d7fabd5f5f042e5366159ca1929e76a865ba3074f041e58/duckdb-1.6.0.dev365-cp312-cp312-win_arm64.whl", hash = "sha256:655594389dd3df0ed26cbe33fdcde8bcd26633bc60b32a9534489f4467897365", size = 14208551, upload-time = "2026-08-20T16:26:36.736Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b2/964a9a944c3fb513260618d4bd3e97529fdc032cc9e0a62e5696ade381a4/duckdb-1.6.0.dev365-cp313-cp313-macosx_10_14_universal2.whl", hash = "sha256:0f3e0bfb6587023012b2e3ea2e6d80b29d278af91937f90acf1e040ece2c2c58", size = 34198899, upload-time = "2026-08-20T16:26:42.555Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a0/0faa4401b2775145b84346a8e98aab7b5053539e8a03bbf138f7f61277dc/duckdb-1.6.0.dev365-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:12e1c00c6af989593c0931d71653a7b39dade2e3b7339a4c76ba3356f0385a3f", size = 18170411, upload-time = "2026-08-20T16:26:46.631Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/6e/de216ab30c1c8d14a17fe8549e73096fce6c5ed4c9848bdab3311c8d8102/duckdb-1.6.0.dev365-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:90a355d912c29d3dc69a0719b95b4d2f59e4a921f3f689a85a0ba40460a01031", size = 16158197, upload-time = "2026-08-20T16:26:50.094Z" },
+    { url = "https://files.pythonhosted.org/packages/53/d8/6ab48e3612af9820a39760530bc4f4dc5956806f1b78ec101d7e1c8d3d11/duckdb-1.6.0.dev365-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ad7df1ce6469e8394bc1267782aa36fe9f6188d9697d0e8fdaea2a298dd7471", size = 20147318, upload-time = "2026-08-20T16:26:53.693Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b0/cb6ff5c8c0b615231e42d1a453cc987c2d329002834b408a37d2b000a242/duckdb-1.6.0.dev365-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:88cf464883f570b006500acbad4ce24e93337164bf9c929e172b890700b0ebf7", size = 22687682, upload-time = "2026-08-20T16:26:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5f/f4681820da8d71f1986a59234d4c8157aa14baf420f43d67165f104fee7d/duckdb-1.6.0.dev365-cp313-cp313-win_amd64.whl", hash = "sha256:70302270d5f668f444b2f224534eca5f4fa055958c587df3e3d4afbfdf7bab3c", size = 13697993, upload-time = "2026-08-20T16:27:01.096Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b1/126132553964e04be6423c961cf80266a923faed06134bbd26a5d2916de8/duckdb-1.6.0.dev365-cp313-cp313-win_arm64.whl", hash = "sha256:1f18601253587dea91ea745d2b5473d5f21387cb0074f28a97bffc0ed4acae2c", size = 14208282, upload-time = "2026-08-20T16:27:04.836Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/27/59b681d10da737bd954d28452d17141568f6d1280527214d0d80a74d2041/duckdb-1.6.0.dev365-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8df6c8652b6705e4efd40acec373b70ab3bdeb428e8641b1629d75b198d29543", size = 34201930, upload-time = "2026-08-20T16:27:10.018Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/09/5f85596b04b0bf6be7f905159d509acf3453055a66fda5fe32c19a06160f/duckdb-1.6.0.dev365-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e91dc5dd50fb7bedabb729f90251f18c92c9fb861b72c760c0486033250eaf6", size = 18170479, upload-time = "2026-08-20T16:27:14.434Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/de/21f6441f38cf101ccfe98286870f42c0b446ba2411ba7e6a22c457392f1f/duckdb-1.6.0.dev365-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5865fed2a51cbf1d89bd30286de12c82a874b234c33c9d994a18228f4614b241", size = 16159317, upload-time = "2026-08-20T16:27:18.38Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d7/3220cdf6a30f8e9ddcfae977fc69ec2370fd2bbae604a7b61abab9d986b1/duckdb-1.6.0.dev365-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90857b8de212c5975f5cdfaa2d298b33d90bbf5e0fee27e7971ef8d56a18e4d0", size = 20150841, upload-time = "2026-08-20T16:27:22.348Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/01/d2633d0e30b776c06ada9bbccfa7caabd10c42d8c62a86b254b021227aa7/duckdb-1.6.0.dev365-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bc5950143bd23ea4e1c94ab2a88d9643c097c45550505e0d0a031d3a6f1212a", size = 22687656, upload-time = "2026-08-20T16:27:26.525Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/47/eee7b58427e8c56ec30001fc63670290967923d3edcd93cba1c2a678f4ef/duckdb-1.6.0.dev365-cp314-cp314-win_amd64.whl", hash = "sha256:d2b607161bcf445b7be3732044293d4cfda4af935b2d4f1cf078ed0291527d5e", size = 14103258, upload-time = "2026-08-20T16:27:29.959Z" },
+    { url = "https://files.pythonhosted.org/packages/26/51/27bb21711059570cb3b84fc80e6fe56181bba4c64fdaf7e92cf3eab256d5/duckdb-1.6.0.dev365-cp314-cp314-win_arm64.whl", hash = "sha256:e8ac7a579f9a59fcf2e49cc1c780b49494030a06e54ac3e2f591dac0621dc5c0", size = 14583850, upload-time = "2026-08-20T16:27:33.881Z" },
 ]
 
 [[package]]
@@ -150,25 +148,30 @@ wheels = [
 
 [[package]]
 name = "harlequin"
-version = "2.4.0"
+version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "duckdb", version = "1.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "duckdb", version = "1.5.0.dev86", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pandas", marker = "python_full_version >= '3.14'" },
+    { name = "duckdb", version = "1.6.0.dev365", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "msgspec" },
     { name = "platformdirs" },
+    { name = "pyperclip" },
     { name = "questionary" },
     { name = "rich-click" },
     { name = "shandy-sqlfmt" },
     { name = "textual" },
     { name = "textual-fastdatatable" },
     { name = "textual-textarea" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tomlkit" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-sql" },
+    { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/a0/759028c7d05143faa097f9f60e67ded4a2cad6117283af7660ba5a47ec37/harlequin-2.4.0.tar.gz", hash = "sha256:2fd424e629aea66fe39ea3fded89cdb3e879ef7f689f2d6e2a77db541a4a8773", size = 107881, upload-time = "2025-10-29T18:18:30.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/f3/a5f4bbf03aad4c97442b3cc66db53b70b4c3d74126321f867a1028ca656b/harlequin-2.11.0.tar.gz", hash = "sha256:9d7d547d673a96fa2d4320934fdd16640999b421c2e72e0287b6c5d843a469c3", size = 211782, upload-time = "2026-08-27T21:27:52.741Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/4b/0cb609eb0312da39545fdfc225b03234aed961aeaa4ddd43e25843b9cd14/harlequin-2.4.0-py3-none-any.whl", hash = "sha256:7e7417f34dfde9a09c2be86b0b5ed2abe215c0f93bdc871cf86a9f839076e5b4", size = 118020, upload-time = "2025-10-29T18:18:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d2/f9d98e47416c0b6320c0e69fba9932bfab05e80446a51825a33ff1adf9ed/harlequin-2.11.0-py3-none-any.whl", hash = "sha256:e5ae98d17965023b84e0dafafa7f6f7b5f53536c1ada504cf5bda823839e15b5", size = 228460, upload-time = "2026-08-27T21:27:49.754Z" },
 ]
 
 [[package]]
@@ -176,7 +179,7 @@ name = "harlequin-postgres"
 version = "1.3.1"
 source = { editable = "." }
 dependencies = [
-    { name = "duckdb", version = "1.5.0.dev86", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "duckdb", version = "1.6.0.dev365", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "harlequin" },
     { name = "psycopg", extra = ["binary", "pool"] },
 ]
@@ -194,13 +197,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "duckdb", marker = "python_full_version >= '3.14'", specifier = ">=1.4.2.dev0" },
-    { name = "harlequin", specifier = ">=1.25,<3" },
+    { name = "harlequin", specifier = ">=2.11,<3" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2,<4" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "harlequin", specifier = "==2.4.0" },
+    { name = "harlequin", specifier = "==2.11.0" },
     { name = "importlib-metadata", marker = "python_full_version < '3.10'", specifier = ">=4.6.0" },
     { name = "mypy", specifier = ">=1.10.0,<2" },
     { name = "pre-commit", specifier = ">=3.5.0,<4" },
@@ -375,6 +378,62 @@ wheels = [
 ]
 
 [[package]]
+name = "msgspec"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/60/f79b9b013a16fa3a58350c9295ddc6789f2e335f36ea61ed10a21b215364/msgspec-0.21.1.tar.gz", hash = "sha256:2313508e394b0d208f8f56892ca9b2799e2561329de9763b19619595a6c0f72c", size = 319193, upload-time = "2026-04-12T21:44:50.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/38/d591d9f66d43d897ecbd249f2833665823d19c8b043f16619bc8343e23df/msgspec-0.21.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72d9cd03241b8b2edb2e12dcc66c500fa480d8cbd71a8bac105809d468882064", size = 195172, upload-time = "2026-04-12T21:43:45.062Z" },
+    { url = "https://files.pythonhosted.org/packages/69/1a/6899188b5982ec1324e0c629b7801eed2db987f6634fab58abd9fc82d317/msgspec-0.21.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ed2ab278200e743a1d2610a4e0c8fc74f6cecb8548544cdec43f927bd9265238", size = 188316, upload-time = "2026-04-12T21:43:46.641Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/95/7e591b4fa11fdbbf9891164473c23420a8c781ef553295abe416bf335f42/msgspec-0.21.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd677e3001fdfed9186de72eab434da2976303cd5eb9550921d3d0c3e3e168ce", size = 216565, upload-time = "2026-04-12T21:43:48.081Z" },
+    { url = "https://files.pythonhosted.org/packages/19/86/714feeaf3b84cf2027235681725593840153dedd2868578f9f2715e296bb/msgspec-0.21.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f667b90b37fad734a91671abd68e0d7f4d066862771b87e91c53996dcb7a9027", size = 222689, upload-time = "2026-04-12T21:43:49.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b9/4384243e814f2579e5205e17d170b9c1a30121afd1393298d904817a7fa7/msgspec-0.21.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:49880fd20fdbcfe1b793f07dd83f12572bab679c9800352c8b2240289aa46a06", size = 222343, upload-time = "2026-04-12T21:43:50.612Z" },
+    { url = "https://files.pythonhosted.org/packages/04/01/4b227d9c4057346271043632bad41979cf8c3dca372e41bb1f7d546395b2/msgspec-0.21.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ae0162e22849a5e91eaad907766525107523b0daea3df267a9fcb5ba4e0936ae", size = 225607, upload-time = "2026-04-12T21:43:52.129Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ce/27021d1c3e5da837743092a7b7a5e8818397e1f4c05ee8b068bd7d1fd78a/msgspec-0.21.1-cp310-cp310-win_amd64.whl", hash = "sha256:f041a2279f31e3a53319005e4d60ba77c085cfcbe394cdc7ce803c2d01fe9449", size = 188392, upload-time = "2026-04-12T21:43:53.384Z" },
+    { url = "https://files.pythonhosted.org/packages/80/2b/daf7a8d6d7cf00e0dcd0439178b284ade701234abdcadf3385601da04fbd/msgspec-0.21.1-cp310-cp310-win_arm64.whl", hash = "sha256:1bf17cbd7b28a5dffc7e764c654eed8ccde5e0f1de7970628608304640d4ce4e", size = 174191, upload-time = "2026-04-12T21:43:54.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7f/bbc4e74cd33d316b75541149e4d35b163b63bce066530ae185a2ec3b5bfc/msgspec-0.21.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b504b6e7f7a22a24b27232b73034421692147865162daaec9f3bf62439007c87", size = 193131, upload-time = "2026-04-12T21:43:56.094Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/60/504886af1aaf854112663b842d5eea9a15d9588f9bf7d0d2df736424b84d/msgspec-0.21.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4692b7c1609155708c4418f88e92f63c13fdf08aa095c84bae82bad75b53389b", size = 186597, upload-time = "2026-04-12T21:43:57.242Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/54/d24ddeaa65b5278c9e67f48ce3c17a9831e8f3722f3c8322ee120aca22ef/msgspec-0.21.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d3124010b3815451494c85ff345e693cb9fe5889cfcbbef39ed8622e0e72319c", size = 215158, upload-time = "2026-04-12T21:43:58.442Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/75/bb79c8b89a93ae23cd33c0d802373f16feaf9633f05d8af77091350dda0a/msgspec-0.21.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6badc03b9725352219cca017bfe71c61f2fbd0fb5982b410ac17c97c213deb30", size = 219856, upload-time = "2026-04-12T21:44:00.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/c5ca26b46f0ebbd3a6683695ef89396712cb9e4199fd1f0bc1dd968216b1/msgspec-0.21.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5d2d4116ebe3035a78d9ec76e99a9d64e5fa6d44fe61a9c5de7fd1acf54bcc69", size = 220314, upload-time = "2026-04-12T21:44:01.548Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/31/645a351c4285dce40ed6755c3dcc0aa648e26dacb20a98018fe2cce5e87b/msgspec-0.21.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0d1009f6715f5bff3b54d4ff5c7428ad96197e0534e1645b8e9b955890c84664", size = 223215, upload-time = "2026-04-12T21:44:02.884Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8bf15736a6dd3cb4f90c5467f6dc39197d2daaf10754490cdc0aa17b7312/msgspec-0.21.1-cp311-cp311-win_amd64.whl", hash = "sha256:c6faffe5bb644ec884052679af4dfd776d4b5ca90e4a7ec7e7e319e4e6b93a6e", size = 188554, upload-time = "2026-04-12T21:44:04.151Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/29/cc7db3a165b62d16e64a83f82eccb79655055cb5bc1f60459a6f9d7c82f2/msgspec-0.21.1-cp311-cp311-win_arm64.whl", hash = "sha256:ee9e3f11fa94603f7d673bf795cfa31b549c4a2c723bc39b45beb1e7f5a3fb99", size = 174517, upload-time = "2026-04-12T21:44:05.66Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/cf/317224852c00248c620a9bcf4b26e2e4ab8afd752f18d2a6ef73ebd423b6/msgspec-0.21.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4248cf0b6129b7d230eacd493c17cc2d4f3989f3bb7f633a928a85b7dcfa251", size = 196188, upload-time = "2026-04-12T21:44:07.181Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/81/074612945c0666078f7366f40000013de9f6ba687491d450df699bceebc9/msgspec-0.21.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5102c7e9b3acff82178449b85006d96310e690291bb1ea0142f1b24bcb8aabcb", size = 188473, upload-time = "2026-04-12T21:44:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/37/655101799590bcc5fddb2bd3fe0e6194e816c2d1da7c361725f5eb89a910/msgspec-0.21.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:846758412e9518252b2ac9bffd6f0e54d9ff614f5f9488df7749f81ff5c80920", size = 218871, upload-time = "2026-04-12T21:44:09.917Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d1/d4cd9fe89c7d400d7a18f86ccc94daa3f0927f53558846fcb60791dce5d6/msgspec-0.21.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21995e74b5c598c2e004110ad66ec7f1b8c20bf2bcf3b2de8fd9a3094422d3ff", size = 225025, upload-time = "2026-04-12T21:44:11.191Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bf/e20549e602b9edccadeeff98760345a416f9cce846a657e8b18e3396b212/msgspec-0.21.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6129f0cca52992e898fd5344187f7c8127b63d810b2fd73e36fca73b4c6475ee", size = 222672, upload-time = "2026-04-12T21:44:12.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/68/04d7a8f0f786545cf9b8c280c57aa6befb5977af6e884b8b54191cbe44b3/msgspec-0.21.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ef3ec2296248d1f8b9231acb051b6d471dfde8f21819e86c9adaaa9f42918521", size = 227303, upload-time = "2026-04-12T21:44:13.709Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4d/619866af2840875be408047bf9e70ceafbae6ab50660de7134ed1b25eb86/msgspec-0.21.1-cp312-cp312-win_amd64.whl", hash = "sha256:d4ab834a054c6f0cbeef6df9e7e1b33d5f1bc7b86dea1d2fd7cad003873e783d", size = 190017, upload-time = "2026-04-12T21:44:14.977Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2e/a8f9eca8fd00e097d7a9e99ba8a4685db994494448e3d4f0b7f6e9a3c0f7/msgspec-0.21.1-cp312-cp312-win_arm64.whl", hash = "sha256:628aaa35c74950a8c59da330d7e98917e1c7188f983745782027748ee4ca573e", size = 175345, upload-time = "2026-04-12T21:44:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/74/f11ede02839b19ff459f88e3145df5d711626ca84da4e23520cebf819367/msgspec-0.21.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:764173717a01743f007e9f74520ed281f24672c604514f7d76c1c3a10e8edb66", size = 196176, upload-time = "2026-04-12T21:44:17.613Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/4476c1bd341418a046c4955aff632ec769315d1e3cb94e6acf86d461f9ed/msgspec-0.21.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:344c7cd0eaed1fb81d7959f99100ef71ec9b536881a376f11b9a6c4803365697", size = 188524, upload-time = "2026-04-12T21:44:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d9/9e9d7d7e5061b47540d03d640fab9b3965ba7ae49c1b2154861c8f007518/msgspec-0.21.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48943e278b3854c2f89f955ddc6f9f430d3f0784b16e47d10604ee0463cd21f5", size = 218880, upload-time = "2026-04-12T21:44:20.028Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/2bb344f34abb4b57e60c7c9c761994e0417b9718ec1460bf00c296f2a7ea/msgspec-0.21.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9aa659ebb0101b1cbc31461212b87e341d961f0ab0772aaf068a99e001ec4aa", size = 225050, upload-time = "2026-04-12T21:44:21.577Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/84/7c1e412f76092277bf760cef12b7979d03314d259ab5b5cafde5d0c1722d/msgspec-0.21.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7b27d1a8ead2b6f5b0c4f2d07b8be1ccfcc041c8a0e704781edebe3ae13c484", size = 222713, upload-time = "2026-04-12T21:44:22.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/27/0bba04b2b4ef05f3d068429410bc71d2cea925f1596a8f41152cccd5edb8/msgspec-0.21.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:38fe93e86b61328fe544cb7fd871fad5a27c8734bfda90f65e5dbe288ae50f61", size = 227259, upload-time = "2026-04-12T21:44:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2d/09574b0eea02fed2c2c1383dbaae2c7f79dc16dcd6487a886000afb5d7c4/msgspec-0.21.1-cp313-cp313-win_amd64.whl", hash = "sha256:8bc666331c35fcce05a7cd2d6221adbe0f6058f8e750711413d22793c080ac6a", size = 189857, upload-time = "2026-04-12T21:44:25.359Z" },
+    { url = "https://files.pythonhosted.org/packages/46/34/105b1576ad182879914f0c821f17ee1d13abb165cb060448f96fe2aff078/msgspec-0.21.1-cp313-cp313-win_arm64.whl", hash = "sha256:42bb1241e0750c1a4346f2aa84db26c5ffd99a4eb3a954927d9f149ff2f42898", size = 175403, upload-time = "2026-04-12T21:44:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ad/86954e987d1d6a5c579e2c2e7832b65e0fff194179fdac4f581536086024/msgspec-0.21.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fab48eb45fdbfbdb2c0edfec00ffc53b6b6085beefc6b50b61e01659f9f8757f", size = 196261, upload-time = "2026-04-12T21:44:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a1/c5e46c3e42b866199365e35d11dddfd1fbd8bba4fdb3c52f965b1607ce94/msgspec-0.21.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3cb779ea0c35bc807ff941d415875c1f69ca0be91a2e907ab99a171811d86a9a", size = 188729, upload-time = "2026-04-12T21:44:28.99Z" },
+    { url = "https://files.pythonhosted.org/packages/85/7d/1e29a319d678d6cb962ae5bdf32a6858ebdf38f73bc654c0e9c742a0c2c8/msgspec-0.21.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68604db36b3b4dd9bf160e436e12798a4738848144cea1aca1cb984011eb160f", size = 219866, upload-time = "2026-04-12T21:44:31.104Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1f/cca084ca2572810fff12ea9dbdcbe39eac048f40daf4a9077b49fcbe8cee/msgspec-0.21.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d6b9dc50948eaf65df54d2fd0ff66e6d8c32f116037209ee861810eb9b676cb", size = 224993, upload-time = "2026-04-12T21:44:32.649Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/d2120fc9d419a89a3a7c13e5b7078798c4b392a96a02a6e2b3ce43a8766c/msgspec-0.21.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:52c5e21930942302394429c5a582ce7e6b62c7f983b3760834c2ce107e0dd6df", size = 223535, upload-time = "2026-04-12T21:44:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/75/17/42418b66a3ad972a89bab73dd78b79cc6282bb488a25e73c853cee7443b9/msgspec-0.21.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:abbb39d65681fa24ed394e01af3d59d869068324f900c61d06062b7fb9980f2f", size = 227222, upload-time = "2026-04-12T21:44:35.093Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/33/265c894268cca88ff67b144ca2b4c522fc8b9a6f1966a3640c70516e78e1/msgspec-0.21.1-cp314-cp314-win_amd64.whl", hash = "sha256:5666b1b560b97b6ec2eb3fca8a502298ebac56e13bbca1f88523538ce83d01ea", size = 193810, upload-time = "2026-04-12T21:44:36.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8f/a6d35f25bf1fc63c492fdd88fdce01ba0875ead48c2b91f90f33653b4131/msgspec-0.21.1-cp314-cp314-win_arm64.whl", hash = "sha256:d8b8578e4c83b14ceea4cef0d0b747e31d9330fe4b03b2b2ad4063866a178f93", size = 179125, upload-time = "2026-04-12T21:44:38.198Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/39/74839641e64b99d87da55af0fc472854d42b46e2183b9e2a67fe1bb2a512/msgspec-0.21.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15f523d51c00ebad412213bfe9f06f0a50ec2b93e0c19e824a2d267cabb48ea2", size = 200171, upload-time = "2026-04-12T21:44:39.414Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9b/ce0cca6d2d87fcd4b6ff97600790494e64f26a2c55d61507cd2755c16193/msgspec-0.21.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e47390360583ba3d5c6cb44cf0a9f61b0a06a899d3c2c00627cedebb2e2884b", size = 192879, upload-time = "2026-04-12T21:44:40.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/08/673a7bb05e5702dc787ddd3011195b509f9867927970da59052211929987/msgspec-0.21.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f60800e6299b798142dc40b0644da77ceac5ea0568be58228417eae14135c847", size = 226281, upload-time = "2026-04-12T21:44:42.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/86508cf57283e9070b3c447e3ab25b792a7a0855a3ea4e0c6d111ac34c97/msgspec-0.21.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f8e9dfcd98419cf7568808470c4317a3fb30bef0e3715b568730a2b272a20d7", size = 229863, upload-time = "2026-04-12T21:44:43.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/62/e7c9367cd08d590559faacd711edbae36840342843e669440363f33c7d36/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92d89dfad13bd1ea640dc3e37e724ed380da1030b272bdf5ecafb983c3ad7c75", size = 230445, upload-time = "2026-04-12T21:44:44.806Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b4/c0f54632103846b658a10930025f4de41c8724b5e4805a5f3b395586cb7e/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d03867786e5d7ba25d666df4b11320c27170f4aeafcb8e3a8b0a50a4fb742ca", size = 231822, upload-time = "2026-04-12T21:44:46.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/1d/0d85cc79d0ccf5508e9c846cc66552a6a16bf92abd1dbd8362617f7b35cd/msgspec-0.21.1-cp314-cp314t-win_amd64.whl", hash = "sha256:740fbf1c9d59992ca3537d6fbe9ebbf9eaf726a65fbf31448e0ecbc710697a63", size = 206650, upload-time = "2026-04-12T21:44:47.601Z" },
+    { url = "https://files.pythonhosted.org/packages/90/91/56c5d560f20e6c20e9e4f55bd0e458f7f162aa689ee350346c04c48eac0b/msgspec-0.21.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0d2cc73df6058d811a126ac3a8ad63a4dfa210c82f9cf5a004802eaf4712de90", size = 183149, upload-time = "2026-04-12T21:44:48.833Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "1.18.2"
 source = { registry = "https://pypi.org/simple" }
@@ -438,226 +497,12 @@ wheels = [
 ]
 
 [[package]]
-name = "numpy"
-version = "2.2.6"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version == '3.13.*'",
-    "python_full_version == '3.12.*'",
-    "python_full_version == '3.11.*'",
-    "python_full_version < '3.11'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3e/ed6db5be21ce87955c0cbd3009f2803f59fa08df21b5df06862e2d8e2bdd/numpy-2.2.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b412caa66f72040e6d268491a59f2c43bf03eb6c96dd8f0307829feb7fa2b6fb", size = 21165245, upload-time = "2025-05-17T21:27:58.555Z" },
-    { url = "https://files.pythonhosted.org/packages/22/c2/4b9221495b2a132cc9d2eb862e21d42a009f5a60e45fc44b00118c174bff/numpy-2.2.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e41fd67c52b86603a91c1a505ebaef50b3314de0213461c7a6e99c9a3beff90", size = 14360048, upload-time = "2025-05-17T21:28:21.406Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/77/dc2fcfc66943c6410e2bf598062f5959372735ffda175b39906d54f02349/numpy-2.2.6-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:37e990a01ae6ec7fe7fa1c26c55ecb672dd98b19c3d0e1d1f326fa13cb38d163", size = 5340542, upload-time = "2025-05-17T21:28:30.931Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/4f/1cb5fdc353a5f5cc7feb692db9b8ec2c3d6405453f982435efc52561df58/numpy-2.2.6-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:5a6429d4be8ca66d889b7cf70f536a397dc45ba6faeb5f8c5427935d9592e9cf", size = 6878301, upload-time = "2025-05-17T21:28:41.613Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/17/96a3acd228cec142fcb8723bd3cc39c2a474f7dcf0a5d16731980bcafa95/numpy-2.2.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:efd28d4e9cd7d7a8d39074a4d44c63eda73401580c5c76acda2ce969e0a38e83", size = 14297320, upload-time = "2025-05-17T21:29:02.78Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/63/3de6a34ad7ad6646ac7d2f55ebc6ad439dbbf9c4370017c50cf403fb19b5/numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc7b73d02efb0e18c000e9ad8b83480dfcd5dfd11065997ed4c6747470ae8915", size = 16801050, upload-time = "2025-05-17T21:29:27.675Z" },
-    { url = "https://files.pythonhosted.org/packages/07/b6/89d837eddef52b3d0cec5c6ba0456c1bf1b9ef6a6672fc2b7873c3ec4e2e/numpy-2.2.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:74d4531beb257d2c3f4b261bfb0fc09e0f9ebb8842d82a7b4209415896adc680", size = 15807034, upload-time = "2025-05-17T21:29:51.102Z" },
-    { url = "https://files.pythonhosted.org/packages/01/c8/dc6ae86e3c61cfec1f178e5c9f7858584049b6093f843bca541f94120920/numpy-2.2.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8fc377d995680230e83241d8a96def29f204b5782f371c532579b4f20607a289", size = 18614185, upload-time = "2025-05-17T21:30:18.703Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/c5/0064b1b7e7c89137b471ccec1fd2282fceaae0ab3a9550f2568782d80357/numpy-2.2.6-cp310-cp310-win32.whl", hash = "sha256:b093dd74e50a8cba3e873868d9e93a85b78e0daf2e98c6797566ad8044e8363d", size = 6527149, upload-time = "2025-05-17T21:30:29.788Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/dd/4b822569d6b96c39d1215dbae0582fd99954dcbcf0c1a13c61783feaca3f/numpy-2.2.6-cp310-cp310-win_amd64.whl", hash = "sha256:f0fd6321b839904e15c46e0d257fdd101dd7f530fe03fd6359c1ea63738703f3", size = 12904620, upload-time = "2025-05-17T21:30:48.994Z" },
-    { url = "https://files.pythonhosted.org/packages/da/a8/4f83e2aa666a9fbf56d6118faaaf5f1974d456b1823fda0a176eff722839/numpy-2.2.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f9f1adb22318e121c5c69a09142811a201ef17ab257a1e66ca3025065b7f53ae", size = 21176963, upload-time = "2025-05-17T21:31:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/2b/64e1affc7972decb74c9e29e5649fac940514910960ba25cd9af4488b66c/numpy-2.2.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c820a93b0255bc360f53eca31a0e676fd1101f673dda8da93454a12e23fc5f7a", size = 14406743, upload-time = "2025-05-17T21:31:41.087Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9f/0121e375000b5e50ffdd8b25bf78d8e1a5aa4cca3f185d41265198c7b834/numpy-2.2.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:3d70692235e759f260c3d837193090014aebdf026dfd167834bcba43e30c2a42", size = 5352616, upload-time = "2025-05-17T21:31:50.072Z" },
-    { url = "https://files.pythonhosted.org/packages/31/0d/b48c405c91693635fbe2dcd7bc84a33a602add5f63286e024d3b6741411c/numpy-2.2.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:481b49095335f8eed42e39e8041327c05b0f6f4780488f61286ed3c01368d491", size = 6889579, upload-time = "2025-05-17T21:32:01.712Z" },
-    { url = "https://files.pythonhosted.org/packages/52/b8/7f0554d49b565d0171eab6e99001846882000883998e7b7d9f0d98b1f934/numpy-2.2.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b64d8d4d17135e00c8e346e0a738deb17e754230d7e0810ac5012750bbd85a5a", size = 14312005, upload-time = "2025-05-17T21:32:23.332Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/dd/2238b898e51bd6d389b7389ffb20d7f4c10066d80351187ec8e303a5a475/numpy-2.2.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba10f8411898fc418a521833e014a77d3ca01c15b0c6cdcce6a0d2897e6dbbdf", size = 16821570, upload-time = "2025-05-17T21:32:47.991Z" },
-    { url = "https://files.pythonhosted.org/packages/83/6c/44d0325722cf644f191042bf47eedad61c1e6df2432ed65cbe28509d404e/numpy-2.2.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bd48227a919f1bafbdda0583705e547892342c26fb127219d60a5c36882609d1", size = 15818548, upload-time = "2025-05-17T21:33:11.728Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/9d/81e8216030ce66be25279098789b665d49ff19eef08bfa8cb96d4957f422/numpy-2.2.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9551a499bf125c1d4f9e250377c1ee2eddd02e01eac6644c080162c0c51778ab", size = 18620521, upload-time = "2025-05-17T21:33:39.139Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/fd/e19617b9530b031db51b0926eed5345ce8ddc669bb3bc0044b23e275ebe8/numpy-2.2.6-cp311-cp311-win32.whl", hash = "sha256:0678000bb9ac1475cd454c6b8c799206af8107e310843532b04d49649c717a47", size = 6525866, upload-time = "2025-05-17T21:33:50.273Z" },
-    { url = "https://files.pythonhosted.org/packages/31/0a/f354fb7176b81747d870f7991dc763e157a934c717b67b58456bc63da3df/numpy-2.2.6-cp311-cp311-win_amd64.whl", hash = "sha256:e8213002e427c69c45a52bbd94163084025f533a55a59d6f9c5b820774ef3303", size = 12907455, upload-time = "2025-05-17T21:34:09.135Z" },
-    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348, upload-time = "2025-05-17T21:34:39.648Z" },
-    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362, upload-time = "2025-05-17T21:35:01.241Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103, upload-time = "2025-05-17T21:35:10.622Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382, upload-time = "2025-05-17T21:35:21.414Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462, upload-time = "2025-05-17T21:35:42.174Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618, upload-time = "2025-05-17T21:36:06.711Z" },
-    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511, upload-time = "2025-05-17T21:36:29.965Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783, upload-time = "2025-05-17T21:36:56.883Z" },
-    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506, upload-time = "2025-05-17T21:37:07.368Z" },
-    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190, upload-time = "2025-05-17T21:37:26.213Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84", size = 20867828, upload-time = "2025-05-17T21:37:56.699Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b", size = 14143006, upload-time = "2025-05-17T21:38:18.291Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d", size = 5076765, upload-time = "2025-05-17T21:38:27.319Z" },
-    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566", size = 6617736, upload-time = "2025-05-17T21:38:38.141Z" },
-    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f", size = 14010719, upload-time = "2025-05-17T21:38:58.433Z" },
-    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f", size = 16526072, upload-time = "2025-05-17T21:39:22.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868", size = 15503213, upload-time = "2025-05-17T21:39:45.865Z" },
-    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d", size = 18316632, upload-time = "2025-05-17T21:40:13.331Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd", size = 6244532, upload-time = "2025-05-17T21:43:46.099Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c", size = 12610885, upload-time = "2025-05-17T21:44:05.145Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6", size = 20963467, upload-time = "2025-05-17T21:40:44Z" },
-    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda", size = 14225144, upload-time = "2025-05-17T21:41:05.695Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40", size = 5200217, upload-time = "2025-05-17T21:41:15.903Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8", size = 6712014, upload-time = "2025-05-17T21:41:27.321Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f", size = 14077935, upload-time = "2025-05-17T21:41:49.738Z" },
-    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa", size = 16600122, upload-time = "2025-05-17T21:42:14.046Z" },
-    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571", size = 15586143, upload-time = "2025-05-17T21:42:37.464Z" },
-    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
-    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
-    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/3b/d94a75f4dbf1ef5d321523ecac21ef23a3cd2ac8b78ae2aac40873590229/numpy-2.2.6-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:0b605b275d7bd0c640cad4e5d30fa701a8d59302e127e5f79138ad62762c3e3d", size = 21040391, upload-time = "2025-05-17T21:44:35.948Z" },
-    { url = "https://files.pythonhosted.org/packages/17/f4/09b2fa1b58f0fb4f7c7963a1649c64c4d315752240377ed74d9cd878f7b5/numpy-2.2.6-pp310-pypy310_pp73-macosx_14_0_x86_64.whl", hash = "sha256:7befc596a7dc9da8a337f79802ee8adb30a552a94f792b9c9d18c840055907db", size = 6786754, upload-time = "2025-05-17T21:44:47.446Z" },
-    { url = "https://files.pythonhosted.org/packages/af/30/feba75f143bdc868a1cc3f44ccfa6c4b9ec522b36458e738cd00f67b573f/numpy-2.2.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce47521a4754c8f4593837384bd3424880629f718d87c5d44f8ed763edd63543", size = 16643476, upload-time = "2025-05-17T21:45:11.871Z" },
-    { url = "https://files.pythonhosted.org/packages/37/48/ac2a9584402fb6c0cd5b5d1a91dcf176b15760130dd386bbafdbfe3640bf/numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00", size = 12812666, upload-time = "2025-05-17T21:45:31.426Z" },
-]
-
-[[package]]
-name = "numpy"
-version = "2.3.4"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.14'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/f4/098d2270d52b41f1bd7db9fc288aaa0400cb48c2a3e2af6fa365d9720947/numpy-2.3.4.tar.gz", hash = "sha256:a7d018bfedb375a8d979ac758b120ba846a7fe764911a64465fd87b8729f4a6a", size = 20582187, upload-time = "2025-10-15T16:18:11.77Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/e7/0e07379944aa8afb49a556a2b54587b828eb41dc9adc56fb7615b678ca53/numpy-2.3.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e78aecd2800b32e8347ce49316d3eaf04aed849cd5b38e0af39f829a4e59f5eb", size = 21259519, upload-time = "2025-10-15T16:15:19.012Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/cb/5a69293561e8819b09e34ed9e873b9a82b5f2ade23dce4c51dc507f6cfe1/numpy-2.3.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7fd09cc5d65bda1e79432859c40978010622112e9194e581e3415a3eccc7f43f", size = 14452796, upload-time = "2025-10-15T16:15:23.094Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/04/ff11611200acd602a1e5129e36cfd25bf01ad8e5cf927baf2e90236eb02e/numpy-2.3.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:1b219560ae2c1de48ead517d085bc2d05b9433f8e49d0955c82e8cd37bd7bf36", size = 5381639, upload-time = "2025-10-15T16:15:25.572Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/77/e95c757a6fe7a48d28a009267408e8aa382630cc1ad1db7451b3bc21dbb4/numpy-2.3.4-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:bafa7d87d4c99752d07815ed7a2c0964f8ab311eb8168f41b910bd01d15b6032", size = 6914296, upload-time = "2025-10-15T16:15:27.079Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/d2/137c7b6841c942124eae921279e5c41b1c34bab0e6fc60c7348e69afd165/numpy-2.3.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36dc13af226aeab72b7abad501d370d606326a0029b9f435eacb3b8c94b8a8b7", size = 14591904, upload-time = "2025-10-15T16:15:29.044Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/32/67e3b0f07b0aba57a078c4ab777a9e8e6bc62f24fb53a2337f75f9691699/numpy-2.3.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7b2f9a18b5ff9824a6af80de4f37f4ec3c2aab05ef08f51c77a093f5b89adda", size = 16939602, upload-time = "2025-10-15T16:15:31.106Z" },
-    { url = "https://files.pythonhosted.org/packages/95/22/9639c30e32c93c4cee3ccdb4b09c2d0fbff4dcd06d36b357da06146530fb/numpy-2.3.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9984bd645a8db6ca15d850ff996856d8762c51a2239225288f08f9050ca240a0", size = 16372661, upload-time = "2025-10-15T16:15:33.546Z" },
-    { url = "https://files.pythonhosted.org/packages/12/e9/a685079529be2b0156ae0c11b13d6be647743095bb51d46589e95be88086/numpy-2.3.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:64c5825affc76942973a70acf438a8ab618dbd692b84cd5ec40a0a0509edc09a", size = 18884682, upload-time = "2025-10-15T16:15:36.105Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/85/f6f00d019b0cc741e64b4e00ce865a57b6bed945d1bbeb1ccadbc647959b/numpy-2.3.4-cp311-cp311-win32.whl", hash = "sha256:ed759bf7a70342f7817d88376eb7142fab9fef8320d6019ef87fae05a99874e1", size = 6570076, upload-time = "2025-10-15T16:15:38.225Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/10/f8850982021cb90e2ec31990291f9e830ce7d94eef432b15066e7cbe0bec/numpy-2.3.4-cp311-cp311-win_amd64.whl", hash = "sha256:faba246fb30ea2a526c2e9645f61612341de1a83fb1e0c5edf4ddda5a9c10996", size = 13089358, upload-time = "2025-10-15T16:15:40.404Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/ad/afdd8351385edf0b3445f9e24210a9c3971ef4de8fd85155462fc4321d79/numpy-2.3.4-cp311-cp311-win_arm64.whl", hash = "sha256:4c01835e718bcebe80394fd0ac66c07cbb90147ebbdad3dcecd3f25de2ae7e2c", size = 10462292, upload-time = "2025-10-15T16:15:42.896Z" },
-    { url = "https://files.pythonhosted.org/packages/96/7a/02420400b736f84317e759291b8edaeee9dc921f72b045475a9cbdb26b17/numpy-2.3.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ef1b5a3e808bc40827b5fa2c8196151a4c5abe110e1726949d7abddfe5c7ae11", size = 20957727, upload-time = "2025-10-15T16:15:44.9Z" },
-    { url = "https://files.pythonhosted.org/packages/18/90/a014805d627aa5750f6f0e878172afb6454552da929144b3c07fcae1bb13/numpy-2.3.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2f91f496a87235c6aaf6d3f3d89b17dba64996abadccb289f48456cff931ca9", size = 14187262, upload-time = "2025-10-15T16:15:47.761Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/e4/0a94b09abe89e500dc748e7515f21a13e30c5c3fe3396e6d4ac108c25fca/numpy-2.3.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:f77e5b3d3da652b474cc80a14084927a5e86a5eccf54ca8ca5cbd697bf7f2667", size = 5115992, upload-time = "2025-10-15T16:15:50.144Z" },
-    { url = "https://files.pythonhosted.org/packages/88/dd/db77c75b055c6157cbd4f9c92c4458daef0dd9cbe6d8d2fe7f803cb64c37/numpy-2.3.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:8ab1c5f5ee40d6e01cbe96de5863e39b215a4d24e7d007cad56c7184fdf4aeef", size = 6648672, upload-time = "2025-10-15T16:15:52.442Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/e6/e31b0d713719610e406c0ea3ae0d90760465b086da8783e2fd835ad59027/numpy-2.3.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77b84453f3adcb994ddbd0d1c5d11db2d6bda1a2b7fd5ac5bd4649d6f5dc682e", size = 14284156, upload-time = "2025-10-15T16:15:54.351Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/58/30a85127bfee6f108282107caf8e06a1f0cc997cb6b52cdee699276fcce4/numpy-2.3.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4121c5beb58a7f9e6dfdee612cb24f4df5cd4db6e8261d7f4d7450a997a65d6a", size = 16641271, upload-time = "2025-10-15T16:15:56.67Z" },
-    { url = "https://files.pythonhosted.org/packages/06/f2/2e06a0f2adf23e3ae29283ad96959267938d0efd20a2e25353b70065bfec/numpy-2.3.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:65611ecbb00ac9846efe04db15cbe6186f562f6bb7e5e05f077e53a599225d16", size = 16059531, upload-time = "2025-10-15T16:15:59.412Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/e7/b106253c7c0d5dc352b9c8fab91afd76a93950998167fa3e5afe4ef3a18f/numpy-2.3.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dabc42f9c6577bcc13001b8810d300fe814b4cfbe8a92c873f269484594f9786", size = 18578983, upload-time = "2025-10-15T16:16:01.804Z" },
-    { url = "https://files.pythonhosted.org/packages/73/e3/04ecc41e71462276ee867ccbef26a4448638eadecf1bc56772c9ed6d0255/numpy-2.3.4-cp312-cp312-win32.whl", hash = "sha256:a49d797192a8d950ca59ee2d0337a4d804f713bb5c3c50e8db26d49666e351dc", size = 6291380, upload-time = "2025-10-15T16:16:03.938Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/a8/566578b10d8d0e9955b1b6cd5db4e9d4592dd0026a941ff7994cedda030a/numpy-2.3.4-cp312-cp312-win_amd64.whl", hash = "sha256:985f1e46358f06c2a09921e8921e2c98168ed4ae12ccd6e5e87a4f1857923f32", size = 12787999, upload-time = "2025-10-15T16:16:05.801Z" },
-    { url = "https://files.pythonhosted.org/packages/58/22/9c903a957d0a8071b607f5b1bff0761d6e608b9a965945411f867d515db1/numpy-2.3.4-cp312-cp312-win_arm64.whl", hash = "sha256:4635239814149e06e2cb9db3dd584b2fa64316c96f10656983b8026a82e6e4db", size = 10197412, upload-time = "2025-10-15T16:16:07.854Z" },
-    { url = "https://files.pythonhosted.org/packages/57/7e/b72610cc91edf138bc588df5150957a4937221ca6058b825b4725c27be62/numpy-2.3.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c090d4860032b857d94144d1a9976b8e36709e40386db289aaf6672de2a81966", size = 20950335, upload-time = "2025-10-15T16:16:10.304Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/46/bdd3370dcea2f95ef14af79dbf81e6927102ddf1cc54adc0024d61252fd9/numpy-2.3.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a13fc473b6db0be619e45f11f9e81260f7302f8d180c49a22b6e6120022596b3", size = 14179878, upload-time = "2025-10-15T16:16:12.595Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/01/5a67cb785bda60f45415d09c2bc245433f1c68dd82eef9c9002c508b5a65/numpy-2.3.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:3634093d0b428e6c32c3a69b78e554f0cd20ee420dcad5a9f3b2a63762ce4197", size = 5108673, upload-time = "2025-10-15T16:16:14.877Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/cd/8428e23a9fcebd33988f4cb61208fda832800ca03781f471f3727a820704/numpy-2.3.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:043885b4f7e6e232d7df4f51ffdef8c36320ee9d5f227b380ea636722c7ed12e", size = 6641438, upload-time = "2025-10-15T16:16:16.805Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d1/913fe563820f3c6b079f992458f7331278dcd7ba8427e8e745af37ddb44f/numpy-2.3.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ee6a571d1e4f0ea6d5f22d6e5fbd6ed1dc2b18542848e1e7301bd190500c9d7", size = 14281290, upload-time = "2025-10-15T16:16:18.764Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/7e/7d306ff7cb143e6d975cfa7eb98a93e73495c4deabb7d1b5ecf09ea0fd69/numpy-2.3.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc8a63918b04b8571789688b2780ab2b4a33ab44bfe8ccea36d3eba51228c953", size = 16636543, upload-time = "2025-10-15T16:16:21.072Z" },
-    { url = "https://files.pythonhosted.org/packages/47/6a/8cfc486237e56ccfb0db234945552a557ca266f022d281a2f577b98e955c/numpy-2.3.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:40cc556d5abbc54aabe2b1ae287042d7bdb80c08edede19f0c0afb36ae586f37", size = 16056117, upload-time = "2025-10-15T16:16:23.369Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/0e/42cb5e69ea901e06ce24bfcc4b5664a56f950a70efdcf221f30d9615f3f3/numpy-2.3.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ecb63014bb7f4ce653f8be7f1df8cbc6093a5a2811211770f6606cc92b5a78fd", size = 18577788, upload-time = "2025-10-15T16:16:27.496Z" },
-    { url = "https://files.pythonhosted.org/packages/86/92/41c3d5157d3177559ef0a35da50f0cda7fa071f4ba2306dd36818591a5bc/numpy-2.3.4-cp313-cp313-win32.whl", hash = "sha256:e8370eb6925bb8c1c4264fec52b0384b44f675f191df91cbe0140ec9f0955646", size = 6282620, upload-time = "2025-10-15T16:16:29.811Z" },
-    { url = "https://files.pythonhosted.org/packages/09/97/fd421e8bc50766665ad35536c2bb4ef916533ba1fdd053a62d96cc7c8b95/numpy-2.3.4-cp313-cp313-win_amd64.whl", hash = "sha256:56209416e81a7893036eea03abcb91c130643eb14233b2515c90dcac963fe99d", size = 12784672, upload-time = "2025-10-15T16:16:31.589Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/df/5474fb2f74970ca8eb978093969b125a84cc3d30e47f82191f981f13a8a0/numpy-2.3.4-cp313-cp313-win_arm64.whl", hash = "sha256:a700a4031bc0fd6936e78a752eefb79092cecad2599ea9c8039c548bc097f9bc", size = 10196702, upload-time = "2025-10-15T16:16:33.902Z" },
-    { url = "https://files.pythonhosted.org/packages/11/83/66ac031464ec1767ea3ed48ce40f615eb441072945e98693bec0bcd056cc/numpy-2.3.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:86966db35c4040fdca64f0816a1c1dd8dbd027d90fca5a57e00e1ca4cd41b879", size = 21049003, upload-time = "2025-10-15T16:16:36.101Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/99/5b14e0e686e61371659a1d5bebd04596b1d72227ce36eed121bb0aeab798/numpy-2.3.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:838f045478638b26c375ee96ea89464d38428c69170360b23a1a50fa4baa3562", size = 14302980, upload-time = "2025-10-15T16:16:39.124Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/44/e9486649cd087d9fc6920e3fc3ac2aba10838d10804b1e179fb7cbc4e634/numpy-2.3.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d7315ed1dab0286adca467377c8381cd748f3dc92235f22a7dfc42745644a96a", size = 5231472, upload-time = "2025-10-15T16:16:41.168Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/51/902b24fa8887e5fe2063fd61b1895a476d0bbf46811ab0c7fdf4bd127345/numpy-2.3.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:84f01a4d18b2cc4ade1814a08e5f3c907b079c847051d720fad15ce37aa930b6", size = 6739342, upload-time = "2025-10-15T16:16:43.777Z" },
-    { url = "https://files.pythonhosted.org/packages/34/f1/4de9586d05b1962acdcdb1dc4af6646361a643f8c864cef7c852bf509740/numpy-2.3.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:817e719a868f0dacde4abdfc5c1910b301877970195db9ab6a5e2c4bd5b121f7", size = 14354338, upload-time = "2025-10-15T16:16:46.081Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/06/1c16103b425de7969d5a76bdf5ada0804b476fed05d5f9e17b777f1cbefd/numpy-2.3.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85e071da78d92a214212cacea81c6da557cab307f2c34b5f85b628e94803f9c0", size = 16702392, upload-time = "2025-10-15T16:16:48.455Z" },
-    { url = "https://files.pythonhosted.org/packages/34/b2/65f4dc1b89b5322093572b6e55161bb42e3e0487067af73627f795cc9d47/numpy-2.3.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2ec646892819370cf3558f518797f16597b4e4669894a2ba712caccc9da53f1f", size = 16134998, upload-time = "2025-10-15T16:16:51.114Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/11/94ec578896cdb973aaf56425d6c7f2aff4186a5c00fac15ff2ec46998b46/numpy-2.3.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:035796aaaddfe2f9664b9a9372f089cfc88bd795a67bd1bfe15e6e770934cf64", size = 18651574, upload-time = "2025-10-15T16:16:53.429Z" },
-    { url = "https://files.pythonhosted.org/packages/62/b7/7efa763ab33dbccf56dade36938a77345ce8e8192d6b39e470ca25ff3cd0/numpy-2.3.4-cp313-cp313t-win32.whl", hash = "sha256:fea80f4f4cf83b54c3a051f2f727870ee51e22f0248d3114b8e755d160b38cfb", size = 6413135, upload-time = "2025-10-15T16:16:55.992Z" },
-    { url = "https://files.pythonhosted.org/packages/43/70/aba4c38e8400abcc2f345e13d972fb36c26409b3e644366db7649015f291/numpy-2.3.4-cp313-cp313t-win_amd64.whl", hash = "sha256:15eea9f306b98e0be91eb344a94c0e630689ef302e10c2ce5f7e11905c704f9c", size = 12928582, upload-time = "2025-10-15T16:16:57.943Z" },
-    { url = "https://files.pythonhosted.org/packages/67/63/871fad5f0073fc00fbbdd7232962ea1ac40eeaae2bba66c76214f7954236/numpy-2.3.4-cp313-cp313t-win_arm64.whl", hash = "sha256:b6c231c9c2fadbae4011ca5e7e83e12dc4a5072f1a1d85a0a7b3ed754d145a40", size = 10266691, upload-time = "2025-10-15T16:17:00.048Z" },
-    { url = "https://files.pythonhosted.org/packages/72/71/ae6170143c115732470ae3a2d01512870dd16e0953f8a6dc89525696069b/numpy-2.3.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:81c3e6d8c97295a7360d367f9f8553973651b76907988bb6066376bc2252f24e", size = 20955580, upload-time = "2025-10-15T16:17:02.509Z" },
-    { url = "https://files.pythonhosted.org/packages/af/39/4be9222ffd6ca8a30eda033d5f753276a9c3426c397bb137d8e19dedd200/numpy-2.3.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7c26b0b2bf58009ed1f38a641f3db4be8d960a417ca96d14e5b06df1506d41ff", size = 14188056, upload-time = "2025-10-15T16:17:04.873Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/3d/d85f6700d0a4aa4f9491030e1021c2b2b7421b2b38d01acd16734a2bfdc7/numpy-2.3.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:62b2198c438058a20b6704351b35a1d7db881812d8512d67a69c9de1f18ca05f", size = 5116555, upload-time = "2025-10-15T16:17:07.499Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/04/82c1467d86f47eee8a19a464c92f90a9bb68ccf14a54c5224d7031241ffb/numpy-2.3.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:9d729d60f8d53a7361707f4b68a9663c968882dd4f09e0d58c044c8bf5faee7b", size = 6643581, upload-time = "2025-10-15T16:17:09.774Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/d3/c79841741b837e293f48bd7db89d0ac7a4f2503b382b78a790ef1dc778a5/numpy-2.3.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd0c630cf256b0a7fd9d0a11c9413b42fef5101219ce6ed5a09624f5a65392c7", size = 14299186, upload-time = "2025-10-15T16:17:11.937Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/7e/4a14a769741fbf237eec5a12a2cbc7a4c4e061852b6533bcb9e9a796c908/numpy-2.3.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5e081bc082825f8b139f9e9fe42942cb4054524598aaeb177ff476cc76d09d2", size = 16638601, upload-time = "2025-10-15T16:17:14.391Z" },
-    { url = "https://files.pythonhosted.org/packages/93/87/1c1de269f002ff0a41173fe01dcc925f4ecff59264cd8f96cf3b60d12c9b/numpy-2.3.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:15fb27364ed84114438fff8aaf998c9e19adbeba08c0b75409f8c452a8692c52", size = 16074219, upload-time = "2025-10-15T16:17:17.058Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/28/18f72ee77408e40a76d691001ae599e712ca2a47ddd2c4f695b16c65f077/numpy-2.3.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:85d9fb2d8cd998c84d13a79a09cc0c1091648e848e4e6249b0ccd7f6b487fa26", size = 18576702, upload-time = "2025-10-15T16:17:19.379Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/76/95650169b465ececa8cf4b2e8f6df255d4bf662775e797ade2025cc51ae6/numpy-2.3.4-cp314-cp314-win32.whl", hash = "sha256:e73d63fd04e3a9d6bc187f5455d81abfad05660b212c8804bf3b407e984cd2bc", size = 6337136, upload-time = "2025-10-15T16:17:22.886Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/89/a231a5c43ede5d6f77ba4a91e915a87dea4aeea76560ba4d2bf185c683f0/numpy-2.3.4-cp314-cp314-win_amd64.whl", hash = "sha256:3da3491cee49cf16157e70f607c03a217ea6647b1cea4819c4f48e53d49139b9", size = 12920542, upload-time = "2025-10-15T16:17:24.783Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/0c/ae9434a888f717c5ed2ff2393b3f344f0ff6f1c793519fa0c540461dc530/numpy-2.3.4-cp314-cp314-win_arm64.whl", hash = "sha256:6d9cd732068e8288dbe2717177320723ccec4fb064123f0caf9bbd90ab5be868", size = 10480213, upload-time = "2025-10-15T16:17:26.935Z" },
-    { url = "https://files.pythonhosted.org/packages/83/4b/c4a5f0841f92536f6b9592694a5b5f68c9ab37b775ff342649eadf9055d3/numpy-2.3.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:22758999b256b595cf0b1d102b133bb61866ba5ceecf15f759623b64c020c9ec", size = 21052280, upload-time = "2025-10-15T16:17:29.638Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/80/90308845fc93b984d2cc96d83e2324ce8ad1fd6efea81b324cba4b673854/numpy-2.3.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9cb177bc55b010b19798dc5497d540dea67fd13a8d9e882b2dae71de0cf09eb3", size = 14302930, upload-time = "2025-10-15T16:17:32.384Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/4e/07439f22f2a3b247cec4d63a713faae55e1141a36e77fb212881f7cda3fb/numpy-2.3.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:0f2bcc76f1e05e5ab58893407c63d90b2029908fa41f9f1cc51eecce936c3365", size = 5231504, upload-time = "2025-10-15T16:17:34.515Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/de/1e11f2547e2fe3d00482b19721855348b94ada8359aef5d40dd57bfae9df/numpy-2.3.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:8dc20bde86802df2ed8397a08d793da0ad7a5fd4ea3ac85d757bf5dd4ad7c252", size = 6739405, upload-time = "2025-10-15T16:17:36.128Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/40/8cd57393a26cebe2e923005db5134a946c62fa56a1087dc7c478f3e30837/numpy-2.3.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e199c087e2aa71c8f9ce1cb7a8e10677dc12457e7cc1be4798632da37c3e86e", size = 14354866, upload-time = "2025-10-15T16:17:38.884Z" },
-    { url = "https://files.pythonhosted.org/packages/93/39/5b3510f023f96874ee6fea2e40dfa99313a00bf3ab779f3c92978f34aace/numpy-2.3.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:85597b2d25ddf655495e2363fe044b0ae999b75bc4d630dc0d886484b03a5eb0", size = 16703296, upload-time = "2025-10-15T16:17:41.564Z" },
-    { url = "https://files.pythonhosted.org/packages/41/0d/19bb163617c8045209c1996c4e427bccbc4bbff1e2c711f39203c8ddbb4a/numpy-2.3.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:04a69abe45b49c5955923cf2c407843d1c85013b424ae8a560bba16c92fe44a0", size = 16136046, upload-time = "2025-10-15T16:17:43.901Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/c1/6dba12fdf68b02a21ac411c9df19afa66bed2540f467150ca64d246b463d/numpy-2.3.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e1708fac43ef8b419c975926ce1eaf793b0c13b7356cfab6ab0dc34c0a02ac0f", size = 18652691, upload-time = "2025-10-15T16:17:46.247Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/73/f85056701dbbbb910c51d846c58d29fd46b30eecd2b6ba760fc8b8a1641b/numpy-2.3.4-cp314-cp314t-win32.whl", hash = "sha256:863e3b5f4d9915aaf1b8ec79ae560ad21f0b8d5e3adc31e73126491bb86dee1d", size = 6485782, upload-time = "2025-10-15T16:17:48.872Z" },
-    { url = "https://files.pythonhosted.org/packages/17/90/28fa6f9865181cb817c2471ee65678afa8a7e2a1fb16141473d5fa6bacc3/numpy-2.3.4-cp314-cp314t-win_amd64.whl", hash = "sha256:962064de37b9aef801d33bc579690f8bfe6c5e70e29b61783f60bcba838a14d6", size = 13113301, upload-time = "2025-10-15T16:17:50.938Z" },
-    { url = "https://files.pythonhosted.org/packages/54/23/08c002201a8e7e1f9afba93b97deceb813252d9cfd0d3351caed123dcf97/numpy-2.3.4-cp314-cp314t-win_arm64.whl", hash = "sha256:8b5a9a39c45d852b62693d9b3f3e0fe052541f804296ff401a72a1b60edafb29", size = 10547532, upload-time = "2025-10-15T16:17:53.48Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b6/64898f51a86ec88ca1257a59c1d7fd077b60082a119affefcdf1dd0df8ca/numpy-2.3.4-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6e274603039f924c0fe5cb73438fa9246699c78a6df1bd3decef9ae592ae1c05", size = 21131552, upload-time = "2025-10-15T16:17:55.845Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4c/f135dc6ebe2b6a3c77f4e4838fa63d350f85c99462012306ada1bd4bc460/numpy-2.3.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d149aee5c72176d9ddbc6803aef9c0f6d2ceeea7626574fc68518da5476fa346", size = 14377796, upload-time = "2025-10-15T16:17:58.308Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/a4/f33f9c23fcc13dd8412fc8614559b5b797e0aba9d8e01dfa8bae10c84004/numpy-2.3.4-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:6d34ed9db9e6395bb6cd33286035f73a59b058169733a9db9f85e650b88df37e", size = 5306904, upload-time = "2025-10-15T16:18:00.596Z" },
-    { url = "https://files.pythonhosted.org/packages/28/af/c44097f25f834360f9fb960fa082863e0bad14a42f36527b2a121abdec56/numpy-2.3.4-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:fdebe771ca06bb8d6abce84e51dca9f7921fe6ad34a0c914541b063e9a68928b", size = 6819682, upload-time = "2025-10-15T16:18:02.32Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/8c/cd283b54c3c2b77e188f63e23039844f56b23bba1712318288c13fe86baf/numpy-2.3.4-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:957e92defe6c08211eb77902253b14fe5b480ebc5112bc741fd5e9cd0608f847", size = 14422300, upload-time = "2025-10-15T16:18:04.271Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/f0/8404db5098d92446b3e3695cf41c6f0ecb703d701cb0b7566ee2177f2eee/numpy-2.3.4-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13b9062e4f5c7ee5c7e5be96f29ba71bc5a37fed3d1d77c37390ae00724d296d", size = 16760806, upload-time = "2025-10-15T16:18:06.668Z" },
-    { url = "https://files.pythonhosted.org/packages/95/8e/2844c3959ce9a63acc7c8e50881133d86666f0420bcde695e115ced0920f/numpy-2.3.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:81b3a59793523e552c4a96109dde028aa4448ae06ccac5a76ff6532a85558a7f", size = 12973130, upload-time = "2025-10-15T16:18:09.397Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
-]
-
-[[package]]
-name = "pandas"
-version = "2.3.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/f7/f425a00df4fcc22b292c6895c6831c0c8ae1d9fac1e024d16f98a9ce8749/pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c", size = 11555763, upload-time = "2025-09-29T23:16:53.287Z" },
-    { url = "https://files.pythonhosted.org/packages/13/4f/66d99628ff8ce7857aca52fed8f0066ce209f96be2fede6cef9f84e8d04f/pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a", size = 10801217, upload-time = "2025-09-29T23:17:04.522Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/03/3fc4a529a7710f890a239cc496fc6d50ad4a0995657dccc1d64695adb9f4/pandas-2.3.3-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5caf26f64126b6c7aec964f74266f435afef1c1b13da3b0636c7518a1fa3e2b1", size = 12148791, upload-time = "2025-09-29T23:17:18.444Z" },
-    { url = "https://files.pythonhosted.org/packages/40/a8/4dac1f8f8235e5d25b9955d02ff6f29396191d4e665d71122c3722ca83c5/pandas-2.3.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd7478f1463441ae4ca7308a70e90b33470fa593429f9d4c578dd00d1fa78838", size = 12769373, upload-time = "2025-09-29T23:17:35.846Z" },
-    { url = "https://files.pythonhosted.org/packages/df/91/82cc5169b6b25440a7fc0ef3a694582418d875c8e3ebf796a6d6470aa578/pandas-2.3.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4793891684806ae50d1288c9bae9330293ab4e083ccd1c5e383c34549c6e4250", size = 13200444, upload-time = "2025-09-29T23:17:49.341Z" },
-    { url = "https://files.pythonhosted.org/packages/10/ae/89b3283800ab58f7af2952704078555fa60c807fff764395bb57ea0b0dbd/pandas-2.3.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:28083c648d9a99a5dd035ec125d42439c6c1c525098c58af0fc38dd1a7a1b3d4", size = 13858459, upload-time = "2025-09-29T23:18:03.722Z" },
-    { url = "https://files.pythonhosted.org/packages/85/72/530900610650f54a35a19476eca5104f38555afccda1aa11a92ee14cb21d/pandas-2.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:503cf027cf9940d2ceaa1a93cfb5f8c8c7e6e90720a2850378f0b3f3b1e06826", size = 11346086, upload-time = "2025-09-29T23:18:18.505Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/fa/7ac648108144a095b4fb6aa3de1954689f7af60a14cf25583f4960ecb878/pandas-2.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:602b8615ebcc4a0c1751e71840428ddebeb142ec02c786e8ad6b1ce3c8dec523", size = 11578790, upload-time = "2025-09-29T23:18:30.065Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/35/74442388c6cf008882d4d4bdfc4109be87e9b8b7ccd097ad1e7f006e2e95/pandas-2.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8fe25fc7b623b0ef6b5009149627e34d2a4657e880948ec3c840e9402e5c1b45", size = 10833831, upload-time = "2025-09-29T23:38:56.071Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/e4/de154cbfeee13383ad58d23017da99390b91d73f8c11856f2095e813201b/pandas-2.3.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b468d3dad6ff947df92dcb32ede5b7bd41a9b3cceef0a30ed925f6d01fb8fa66", size = 12199267, upload-time = "2025-09-29T23:18:41.627Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/c9/63f8d545568d9ab91476b1818b4741f521646cbdd151c6efebf40d6de6f7/pandas-2.3.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b98560e98cb334799c0b07ca7967ac361a47326e9b4e5a7dfb5ab2b1c9d35a1b", size = 12789281, upload-time = "2025-09-29T23:18:56.834Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/00/a5ac8c7a0e67fd1a6059e40aa08fa1c52cc00709077d2300e210c3ce0322/pandas-2.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37b5848ba49824e5c30bedb9c830ab9b7751fd049bc7914533e01c65f79791", size = 13240453, upload-time = "2025-09-29T23:19:09.247Z" },
-    { url = "https://files.pythonhosted.org/packages/27/4d/5c23a5bc7bd209231618dd9e606ce076272c9bc4f12023a70e03a86b4067/pandas-2.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:db4301b2d1f926ae677a751eb2bd0e8c5f5319c9cb3f88b0becbbb0b07b34151", size = 13890361, upload-time = "2025-09-29T23:19:25.342Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/59/712db1d7040520de7a4965df15b774348980e6df45c129b8c64d0dbe74ef/pandas-2.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:f086f6fe114e19d92014a1966f43a3e62285109afe874f067f5abbdcbb10e59c", size = 11348702, upload-time = "2025-09-29T23:19:38.296Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/fb/231d89e8637c808b997d172b18e9d4a4bc7bf31296196c260526055d1ea0/pandas-2.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d21f6d74eb1725c2efaa71a2bfc661a0689579b58e9c0ca58a739ff0b002b53", size = 11597846, upload-time = "2025-09-29T23:19:48.856Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3fd2f887589c7aa868e02632612ba39acb0b8948faf5cc58f0850e165bd46f35", size = 10729618, upload-time = "2025-09-29T23:39:08.659Z" },
-    { url = "https://files.pythonhosted.org/packages/57/56/cf2dbe1a3f5271370669475ead12ce77c61726ffd19a35546e31aa8edf4e/pandas-2.3.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecaf1e12bdc03c86ad4a7ea848d66c685cb6851d807a26aa245ca3d2017a1908", size = 11737212, upload-time = "2025-09-29T23:19:59.765Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/63/cd7d615331b328e287d8233ba9fdf191a9c2d11b6af0c7a59cfcec23de68/pandas-2.3.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3d11d2fda7eb164ef27ffc14b4fcab16a80e1ce67e9f57e19ec0afaf715ba89", size = 12362693, upload-time = "2025-09-29T23:20:14.098Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/de/8b1895b107277d52f2b42d3a6806e69cfef0d5cf1d0ba343470b9d8e0a04/pandas-2.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a68e15f780eddf2b07d242e17a04aa187a7ee12b40b930bfdd78070556550e98", size = 12771002, upload-time = "2025-09-29T23:20:26.76Z" },
-    { url = "https://files.pythonhosted.org/packages/87/21/84072af3187a677c5893b170ba2c8fbe450a6ff911234916da889b698220/pandas-2.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:371a4ab48e950033bcf52b6527eccb564f52dc826c02afd9a1bc0ab731bba084", size = 13450971, upload-time = "2025-09-29T23:20:41.344Z" },
-    { url = "https://files.pythonhosted.org/packages/86/41/585a168330ff063014880a80d744219dbf1dd7a1c706e75ab3425a987384/pandas-2.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:a16dcec078a01eeef8ee61bf64074b4e524a2a3f4b3be9326420cabe59c4778b", size = 10992722, upload-time = "2025-09-29T23:20:54.139Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/4b/18b035ee18f97c1040d94debd8f2e737000ad70ccc8f5513f4eefad75f4b/pandas-2.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:56851a737e3470de7fa88e6131f41281ed440d29a9268dcbf0002da5ac366713", size = 11544671, upload-time = "2025-09-29T23:21:05.024Z" },
-    { url = "https://files.pythonhosted.org/packages/31/94/72fac03573102779920099bcac1c3b05975c2cb5f01eac609faf34bed1ca/pandas-2.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bdcd9d1167f4885211e401b3036c0c8d9e274eee67ea8d0758a256d60704cfe8", size = 10680807, upload-time = "2025-09-29T23:21:15.979Z" },
-    { url = "https://files.pythonhosted.org/packages/16/87/9472cf4a487d848476865321de18cc8c920b8cab98453ab79dbbc98db63a/pandas-2.3.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e32e7cc9af0f1cc15548288a51a3b681cc2a219faa838e995f7dc53dbab1062d", size = 11709872, upload-time = "2025-09-29T23:21:27.165Z" },
-    { url = "https://files.pythonhosted.org/packages/15/07/284f757f63f8a8d69ed4472bfd85122bd086e637bf4ed09de572d575a693/pandas-2.3.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318d77e0e42a628c04dc56bcef4b40de67918f7041c2b061af1da41dcff670ac", size = 12306371, upload-time = "2025-09-29T23:21:40.532Z" },
-    { url = "https://files.pythonhosted.org/packages/33/81/a3afc88fca4aa925804a27d2676d22dcd2031c2ebe08aabd0ae55b9ff282/pandas-2.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e0a175408804d566144e170d0476b15d78458795bb18f1304fb94160cabf40c", size = 12765333, upload-time = "2025-09-29T23:21:55.77Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/0f/b4d4ae743a83742f1153464cf1a8ecfafc3ac59722a0b5c8602310cb7158/pandas-2.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:93c2d9ab0fc11822b5eece72ec9587e172f63cff87c00b062f6e37448ced4493", size = 13418120, upload-time = "2025-09-29T23:22:10.109Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/c7/e54682c96a895d0c808453269e0b5928a07a127a15704fedb643e9b0a4c8/pandas-2.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bfc0e12dc78f777f323f55c58649591b2cd0c43534e8355c51d3fede5f4dee", size = 10993991, upload-time = "2025-09-29T23:25:04.889Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/ca/3f8d4f49740799189e1395812f3bf23b5e8fc7c190827d55a610da72ce55/pandas-2.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:75ea25f9529fdec2d2e93a42c523962261e567d250b0013b16210e1d40d7c2e5", size = 12048227, upload-time = "2025-09-29T23:22:24.343Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/5a/f43efec3e8c0cc92c4663ccad372dbdff72b60bdb56b2749f04aa1d07d7e/pandas-2.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74ecdf1d301e812db96a465a525952f4dde225fdb6d8e5a521d47e1f42041e21", size = 11411056, upload-time = "2025-09-29T23:22:37.762Z" },
-    { url = "https://files.pythonhosted.org/packages/46/b1/85331edfc591208c9d1a63a06baa67b21d332e63b7a591a5ba42a10bb507/pandas-2.3.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6435cb949cb34ec11cc9860246ccb2fdc9ecd742c12d3304989017d53f039a78", size = 11645189, upload-time = "2025-09-29T23:22:51.688Z" },
-    { url = "https://files.pythonhosted.org/packages/44/23/78d645adc35d94d1ac4f2a3c4112ab6f5b8999f4898b8cdf01252f8df4a9/pandas-2.3.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900f47d8f20860de523a1ac881c4c36d65efcb2eb850e6948140fa781736e110", size = 12121912, upload-time = "2025-09-29T23:23:05.042Z" },
-    { url = "https://files.pythonhosted.org/packages/53/da/d10013df5e6aaef6b425aa0c32e1fc1f3e431e4bcabd420517dceadce354/pandas-2.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a45c765238e2ed7d7c608fc5bc4a6f88b642f2f01e70c0c23d2224dd21829d86", size = 12712160, upload-time = "2025-09-29T23:23:28.57Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/17/e756653095a083d8a37cbd816cb87148debcfcd920129b25f99dd8d04271/pandas-2.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c4fc4c21971a1a9f4bdb4c73978c7f7256caa3e62b323f70d6cb80db583350bc", size = 13199233, upload-time = "2025-09-29T23:24:24.876Z" },
-    { url = "https://files.pythonhosted.org/packages/04/fd/74903979833db8390b73b3a8a7d30d146d710bd32703724dd9083950386f/pandas-2.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:ee15f284898e7b246df8087fc82b87b01686f98ee67d85a17b7ab44143a3a9a0", size = 11540635, upload-time = "2025-09-29T23:25:52.486Z" },
-    { url = "https://files.pythonhosted.org/packages/21/00/266d6b357ad5e6d3ad55093a7e8efc7dd245f5a842b584db9f30b0f0a287/pandas-2.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1611aedd912e1ff81ff41c745822980c49ce4a7907537be8692c8dbc31924593", size = 10759079, upload-time = "2025-09-29T23:26:33.204Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/05/d01ef80a7a3a12b2f8bbf16daba1e17c98a2f039cbc8e2f77a2c5a63d382/pandas-2.3.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d2cefc361461662ac48810cb14365a365ce864afe85ef1f447ff5a1e99ea81c", size = 11814049, upload-time = "2025-09-29T23:27:15.384Z" },
-    { url = "https://files.pythonhosted.org/packages/15/b2/0e62f78c0c5ba7e3d2c5945a82456f4fac76c480940f805e0b97fcbc2f65/pandas-2.3.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ee67acbbf05014ea6c763beb097e03cd629961c8a632075eeb34247120abcb4b", size = 12332638, upload-time = "2025-09-29T23:27:51.625Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/33/dd70400631b62b9b29c3c93d2feee1d0964dc2bae2e5ad7a6c73a7f25325/pandas-2.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c46467899aaa4da076d5abc11084634e2d197e9460643dd455ac3db5856b24d6", size = 12886834, upload-time = "2025-09-29T23:28:21.289Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/18/b5d48f55821228d0d2692b34fd5034bb185e854bdb592e9c640f6290e012/pandas-2.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6253c72c6a1d990a410bc7de641d34053364ef8bcd3126f7e7450125887dffe3", size = 13409925, upload-time = "2025-09-29T23:28:58.261Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/3d/124ac75fcd0ecc09b8fdccb0246ef65e35b012030defb0e0eba2cbbbe948/pandas-2.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:1b07204a219b3b7350abaae088f451860223a52cfb8a6c53358e7948735158e5", size = 11109071, upload-time = "2025-09-29T23:32:27.484Z" },
-    { url = "https://files.pythonhosted.org/packages/89/9c/0e21c895c38a157e0faa1fb64587a9226d6dd46452cac4532d80c3c4a244/pandas-2.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:2462b1a365b6109d275250baaae7b760fd25c726aaca0054649286bcfbb3e8ec", size = 12048504, upload-time = "2025-09-29T23:29:31.47Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/82/b69a1c95df796858777b68fbe6a81d37443a33319761d7c652ce77797475/pandas-2.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0242fe9a49aa8b4d78a4fa03acb397a58833ef6199e9aa40a95f027bb3a1b6e7", size = 11410702, upload-time = "2025-09-29T23:29:54.591Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/88/702bde3ba0a94b8c73a0181e05144b10f13f29ebfc2150c3a79062a8195d/pandas-2.3.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a21d830e78df0a515db2b3d2f5570610f5e6bd2e27749770e8bb7b524b89b450", size = 11634535, upload-time = "2025-09-29T23:30:21.003Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/1e/1bac1a839d12e6a82ec6cb40cda2edde64a2013a66963293696bbf31fbbb/pandas-2.3.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e3ebdb170b5ef78f19bfb71b0dc5dc58775032361fa188e814959b74d726dd5", size = 12121582, upload-time = "2025-09-29T23:30:43.391Z" },
-    { url = "https://files.pythonhosted.org/packages/44/91/483de934193e12a3b1d6ae7c8645d083ff88dec75f46e827562f1e4b4da6/pandas-2.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d051c0e065b94b7a3cea50eb1ec32e912cd96dba41647eb24104b6c6c14c5788", size = 12699963, upload-time = "2025-09-29T23:31:10.009Z" },
-    { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
 ]
 
 [[package]]
@@ -993,27 +838,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "pytz"
-version = "2025.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload-time = "2025-03-25T02:25:00.538Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload-time = "2025-03-25T02:24:58.468Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1079,14 +903,14 @@ wheels = [
 
 [[package]]
 name = "questionary"
-version = "2.0.1"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "prompt-toolkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/d0/d73525aeba800df7030ac187d09c59dc40df1c878b4fab8669bdc805535d/questionary-2.0.1.tar.gz", hash = "sha256:bcce898bf3dbb446ff62830c86c5c6fb9a22a54146f0f5597d3da43b10d8fc8b", size = 24726, upload-time = "2023-09-08T12:19:03.316Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/e7/2dd8f59d1d328773505f78b85405ddb1cfe74126425d076ce72e65540b8b/questionary-2.0.1-py3-none-any.whl", hash = "sha256:8ab9a01d0b91b68444dff7f6652c1e754105533f083cbe27597c8110ecc230a2", size = 34248, upload-time = "2023-09-08T12:19:01.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]
@@ -1104,16 +928,17 @@ wheels = [
 
 [[package]]
 name = "rich-click"
-version = "1.8.5"
+version = "1.9.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/31/103501e85e885e3e202c087fa612cfe450693210372766552ce1ab5b57b9/rich_click-1.8.5.tar.gz", hash = "sha256:a3eebe81da1c9da3c32f3810017c79bd687ff1b3fa35bfc9d8a3338797f1d1a1", size = 38229, upload-time = "2024-12-01T19:49:22.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ea/21e4867ea0ef881ffd4c0550fc21a061435e50d6324bcd034396633cbc18/rich_click-1.9.8.tar.gz", hash = "sha256:4008f921da88b5d91646c134ec881c1500e5a6b3f093e90e8f29400e09608371", size = 75363, upload-time = "2026-05-28T19:54:59.144Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/0b/e2de98c538c0ee9336211d260f88b7e69affab44969750aaca0b48a697c8/rich_click-1.8.5-py3-none-any.whl", hash = "sha256:0fab7bb5b66c15da17c210b4104277cd45f3653a7322e0098820a169880baee0", size = 35081, upload-time = "2024-12-01T19:49:21.083Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/97/a87901aef6b7e7e4a34c6dd6cc17dca8594a592ef9d9dd765fca2b7facf7/rich_click-1.9.8-py3-none-any.whl", hash = "sha256:12873865396e6927835d4eabb1cc3996edcd65b7ac9b2391a29eca4f335a2f93", size = 72189, upload-time = "2026-05-28T19:54:57.867Z" },
 ]
 
 [[package]]
@@ -1144,7 +969,7 @@ wheels = [
 
 [[package]]
 name = "shandy-sqlfmt"
-version = "0.28.2"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1153,23 +978,14 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/83/96/9e4ecbe43d4bb91d651f5f091c5f72204461b1568dc5a5eaa246a64b562f/shandy_sqlfmt-0.28.2.tar.gz", hash = "sha256:0a78a2eee23f8b84b19a2895ca4608237d6da19037ce71346417fe01e97bad8b", size = 70725, upload-time = "2025-10-25T04:26:51.28Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/61/29e13aa8c39da9fe821fb393c4113b166517a38d8a2bb53142c9b6dd0892/shandy_sqlfmt-0.32.0.tar.gz", hash = "sha256:f1e93928659f8159e399f189050b60dbe2135812eccfc1566b04644fb0dc3304", size = 72148, upload-time = "2026-08-10T15:42:53.05Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/2b/71998158977befe818fb214d7aa06eace64023ef1608eb87d6591ab73957/shandy_sqlfmt-0.28.2-py3-none-any.whl", hash = "sha256:5c0bda7e66cf8782d960f22c97c22d98541d6e75febd6b21b94c10ca6eb2514f", size = 71857, upload-time = "2025-10-25T04:26:49.797Z" },
-]
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/c7/336524d9e60d670c493a034b2c53ea3cefffb55ab7cc0248f8377f1b9a97/shandy_sqlfmt-0.32.0-py3-none-any.whl", hash = "sha256:716cfa4910c318a7b905002f73c95a0ef6bdc4a23e79b6fa2ad1c0f6aab3ee46", size = 72726, upload-time = "2026-08-10T15:42:51.738Z" },
 ]
 
 [[package]]
 name = "textual"
-version = "6.4.0"
+version = "8.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", extra = ["linkify"] },
@@ -1179,9 +995,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/6c/565521dc6dd00fa857845483ae0c070575fda1f9a56d92d732554fecfea4/textual-6.4.0.tar.gz", hash = "sha256:f40df9165a001c10249698d532f2f5a71708b70f0e4ef3fce081a9dd93ffeaaa", size = 1573599, upload-time = "2025-10-22T17:29:51.357Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/20/6eed0e55bdd2576475e9cea49cc71c47f8e56ab54f04cbe04b2fb56440de/textual-6.4.0-py3-none-any.whl", hash = "sha256:b346dbb8e12f17cefb33ddfdf7f19bdc9e66c29daf82fc981a8db6b7d985e115", size = 711663, upload-time = "2025-10-22T17:29:49.346Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
 ]
 
 [package.optional-dependencies]
@@ -1206,33 +1022,31 @@ syntax = [
 
 [[package]]
 name = "textual-fastdatatable"
-version = "0.14.0"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
-    { name = "numpy", version = "2.3.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "pandas" },
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "textual" },
+    { name = "typing-extensions" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/ec/8cc2204560200dcc80abc432a61eb6f99672049aecfd0860472cfc3f82fe/textual_fastdatatable-0.14.0.tar.gz", hash = "sha256:cb99e208fb96c7eb5cfb7f225a280da950bd8cfb29d685a49071787c80218901", size = 35202, upload-time = "2025-10-25T17:44:46.786Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/a4/e3f2834ed4393afda3b66a4a8133e1b42e1269dd547d5f2064818d814273/textual_fastdatatable-0.19.0.tar.gz", hash = "sha256:c9ffa17978e68886be3462c980fece81d21a5d0d5957d9eef2e5c6dae649606f", size = 46345, upload-time = "2026-08-20T04:13:55.754Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/c6/92b5af55575997aeba1d434dedadcc333eab83c47d5e8b3b0d8b7dca0250/textual_fastdatatable-0.14.0-py3-none-any.whl", hash = "sha256:4873ed8f339365c284f98e2e7f8fffbdcaef0a74b8c031d86d91964569c56986", size = 33301, upload-time = "2025-10-25T17:44:43.969Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e8/0d6ed7f40908ff0ca53651e5617861bf7bebadfb526030c9735f3e0c410f/textual_fastdatatable-0.19.0-py3-none-any.whl", hash = "sha256:1ba54ca17de1d03ded54e8ab92ba6e2aa07c4d9765006bad1deba3923a38618d", size = 43348, upload-time = "2026-08-20T04:13:54.314Z" },
 ]
 
 [[package]]
 name = "textual-textarea"
-version = "0.17.2"
+version = "0.18.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyperclip" },
     { name = "textual", extra = ["syntax"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/9e/1aa70bab939cac85442cbfe3ef94383329b6cbe2535223940f6846252582/textual_textarea-0.17.2.tar.gz", hash = "sha256:84bb2bfe545db70071914802e808dc411c16c21e7744adbcfc381f1390dd2c6b", size = 27615, upload-time = "2025-10-24T21:32:54.62Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/e4/aa225ac619c07149b18864a240fd8cc6a710e8ffc01028bafa0059ace893/textual_textarea-0.18.1.tar.gz", hash = "sha256:9db53da7659883cd905e66eabae11943c5b2e3a7530873ff85ee35d4bc3d928d", size = 28902, upload-time = "2026-08-05T17:35:48.676Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/7e/fc0192c7e598c80c88c83cd0a11dbbe6821d557b48548082a0102fc3256e/textual_textarea-0.17.2-py3-none-any.whl", hash = "sha256:c416f6dd613269ca9746df0074897435c80bea18d75d75d24aea822574d2ade1", size = 26710, upload-time = "2025-10-24T21:32:53.035Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/79/b117fd8f78fffffad74a411e9c48883a69bb4dbd8dff720263ec6c9949ed/textual_textarea-0.18.1-py3-none-any.whl", hash = "sha256:a99c072ab38fe667b9486f099d3dae2a99a59ca1f2207c0c143d0d5015cffe8d", size = 27343, upload-time = "2026-08-05T17:35:47.53Z" },
 ]
 
 [[package]]
@@ -1286,11 +1100,11 @@ wheels = [
 
 [[package]]
 name = "tomlkit"
-version = "0.13.3"
+version = "0.15.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207, upload-time = "2025-06-05T07:13:44.947Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/96/e07752635b98536177fa1f37671c8f3cdde2e724c6bcf6034b2cfb571565/tomlkit-0.15.1.tar.gz", hash = "sha256:e25bbf38843005246210a12982776f27f99cb9be67160e14434d0c0d21ee1e97", size = 180129, upload-time = "2026-07-17T01:48:04.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901, upload-time = "2025-06-05T07:13:43.546Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bc/8c13eb66537dce1d2bd3a57132902f38d0e7f5bb46fa9f4daed9fe9d76ee/tomlkit-0.15.1-py3-none-any.whl", hash = "sha256:177a05aece5a8ca5266fd3c448abb47b8d352f09d477d3ca8332db4d89b24304", size = 49449, upload-time = "2026-07-17T01:48:05.728Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #59.

Adds `HarlequinPostgresConnection.search_catalog()` and sets `IMPLEMENTS_CATALOG_SEARCH = True`, so `hsql --catalog-search TERM` answers where an object lives without walking the catalog a level at a time.

## How the query is shaped

One query per `kind`, unioning a branch for each level of the catalog, every branch in the same six columns (`catalog, schema, relation, relation_type, column, column_type`). A row names the deepest level it fills in and leaves the rest null, so `all` is every level rather than the two at the bottom. `order by 1, 2 nulls first, 3 nulls first, 5 nulls first` makes an item arrive before its children — the `nulls first` is explicit because Postgres sorts nulls last ascending, and without it a schema would arrive after the relations under it.

Matching is a case-insensitive substring via `ilike`, with `\`, `%` and `_` in the term escaped before they reach the pattern, so a search for `customer_id` does not also match `customerxid`.

## Notes specific to this adapter

- **Materialized views get their own two branches** (`pg_matviews`, `pg_attribute`) — matviews are not in `information_schema`, which is the same reason `_get_mvs()` and `_get_mv_cols()` exist. Without them, a matview would be findable by walking but not by searching.
- **System schemas are filtered exactly as `_get_schemas()` filters them**, so a search only reports paths `--catalog` also walks.
- **Relations and columns come from the connected database**, the one the pool is bound to. The other databases on the server are matched by name from `pg_database`, which is all `_get_databases()` reads for them, and is the `kind="all"` top level.
- **Items are built with the classes `fetch_children()` uses**, so labels, type labels and query names match what `--catalog` shows for the same object. There is a test asserting that parity directly.
- Errors from psycopg become `HarlequinQueryError`, and the connection goes back to the pool in a `finally`, so a failed search does not cost a connection.

## Also: `type_name` on catalog items

Second commit, on both the walk and the search so the two agree: every item now carries the full type its short `type_label` is shortened from — `BASE TABLE`, `VIEW`, `MATERIALIZED VIEW`, `LOCAL TEMPORARY`, `FOREIGN` for relations, and the column's type as Postgres spells it for columns. Databases and schemas keep `type_name = None`; their `db`/`sch` labels are not shortened from anything the database says. Both call sites pass through what the database reported rather than relabeling, so an unexpected `table_type` is reported honestly.

The `type` column that `hsql` prints was `NULL` for this adapter before, on both paths:

```
 path                           | name      | type              | type_label
--------------------------------+-----------+-------------------+------------
 searchdemo.analytics.orders    | orders    | BASE TABLE        | t
 searchdemo.analytics.orders_mv | orders_mv | MATERIALIZED VIEW | mv
```

## Dependency bump

`search_catalog()` needs to import `CatalogSearchKind` and `CatalogSearchResult`, which first exist in harlequin 2.11.0 (as does `IMPLEMENTS_CATALOG_SEARCH`), so the floor moves from `harlequin>=1.25,<3` to `>=2.11,<3` and the dev pin from 2.4.0 to 2.11.0. That drops harlequin 1.x compatibility — noted in the CHANGELOG. The alternative was a lazy import inside the method to keep older cores installable; that did not seem worth the complexity for a plugin to the current app, but it is a one-line reversal if you would rather keep the loose floor.

## Testing

`ruff format`, `ruff check`, `mypy` and `pytest` all pass — 56 tests, 18 of them new. Docker Hub is unreachable from this environment, so the suite ran against a local Postgres 16 rather than `docker-compose`.

New coverage: each `kind`, case-insensitivity, substring matching, `%`/`_` escaping, matviews and their columns at both levels, databases matched by name, system schemas excluded, the empty result, error wrapping (and that the connection returns to the pool afterward), ordering parents before children, `type_name` on the walk, and item-for-item parity between search and `fetch_children()`.

End to end, `hsql --catalog-search` returns rows identical to what `hsql --catalog --path` prints for the same objects, and `hsql --info` reports `implements_catalog_search: true`.

## One thing left out

While working on this I noticed that every pooled catalog query returns its connection in a transaction, so `psycopg_pool` logs `rolling back returned connection` for each one — pre-existing, and it applies to all eight introspection helpers, not just the new query. Filed as #61 rather than folding a repo-wide refactor into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01844Fwi7DeQAvj7y1Yb9sRD

---
_Generated by [Claude Code](https://claude.ai/code/session_01844Fwi7DeQAvj7y1Yb9sRD)_