### PR TITLE
feat: expose editable_columns() on the cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Adds `HarlequinPostgresCursor.editable_columns()`, which reports the source table, source column, and primary-key flag for result columns that come from a plain table (used by Harlequin's in-place cell editing, tconbeer/harlequin#987, to build a safe `update`). Works across joins.
+
 ## [1.4.0] - 2026-08-29
 
 - This adapter now supports Harlequin's `--read-only` option and declares `IMPLEMENTS_READ_ONLY`. Read-only connections are enforced by the server, using `set session characteristics as transaction read only` ([#58](https://github.com/tconbeer/harlequin-postgres/issues/58)).

--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -181,6 +181,57 @@ class HarlequinPostgresCursor(HarlequinCursor):
         assert cur.description is not None
         self.description = cur.description.copy()
         self._limit: int | None = None
+        # each result column's source table OID and column number, read from the
+        # libpq result while the cursor is open; an OID of 0 marks a computed column
+        self._column_sources: list[tuple[int, int]] = []
+        try:
+            pgresult = cur.pgresult
+            if pgresult is not None:
+                self._column_sources = [
+                    (pgresult.ftable(i), pgresult.ftablecol(i))
+                    for i in range(pgresult.nfields)
+                ]
+        except Exception:
+            self._column_sources = []
+
+    def editable_columns(self) -> dict[int, tuple[str, str, bool]]:
+        """Map result-column index -> (qualified_table, quoted_column, is_primary_key)
+        for result columns that come from a plain table (relkind 'r'/'p'), so they
+        can be edited in place. is_primary_key marks columns usable to identify the
+        row in an UPDATE's WHERE clause. Works across joins; returns {} if none."""
+        source_oids = sorted({oid for oid, _ in self._column_sources if oid})
+        if not source_oids:
+            return {}
+        query = """
+            select a.attrelid as toid, a.attnum as attnum,
+                   n.nspname as schema, c.relname as tbl, a.attname as col,
+                   coalesce(bool_or(pk.is_pk), false) as is_pk
+            from pg_attribute a
+            join pg_class c on a.attrelid = c.oid and c.relkind in ('r', 'p')
+            join pg_namespace n on c.relnamespace = n.oid
+            left join (
+                select con.conrelid as toid, unnest(con.conkey) as attnum,
+                       true as is_pk
+                from pg_constraint con
+                where con.contype = 'p'
+            ) pk on pk.toid = a.attrelid and pk.attnum = a.attnum
+            where a.attrelid = any(%s) and a.attnum > 0 and not a.attisdropped
+            group by a.attrelid, a.attnum, n.nspname, c.relname, a.attname
+        """
+        try:
+            with self.conn.pool.connection() as c:
+                rows = c.execute(query, (source_oids,)).fetchall()
+        except Exception:
+            return {}
+        info_by_source = {
+            (toid, attnum): (f'"{schema}"."{tbl}"', f'"{col}"', is_pk)
+            for (toid, attnum, schema, tbl, col, is_pk) in rows
+        }
+        return {
+            idx: info_by_source[(oid, attnum)]
+            for idx, (oid, attnum) in enumerate(self._column_sources)
+            if (oid, attnum) in info_by_source
+        }
 
     def columns(self) -> list[tuple[str, str]]:
         return [

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -13,6 +13,7 @@ from textual_fastdatatable.backend import create_backend
 from harlequin_postgres.adapter import (
     HarlequinPostgresAdapter,
     HarlequinPostgresConnection,
+    HarlequinPostgresCursor,
 )
 
 if sys.version_info < (3, 10):
@@ -294,3 +295,42 @@ def test_read_only_enforced_in_autocommit_session(
     assert read_only_connection._main_conn.autocommit is True
     with pytest.raises(HarlequinQueryError):
         read_only_connection.execute("insert into foo values (2)")
+
+
+def test_editable_columns_marks_table_columns_and_pk(
+    connection: HarlequinPostgresConnection,
+) -> None:
+    connection.execute("create table ed (id int primary key, name text)")
+    cur = connection.execute("select id, name from ed")
+    assert isinstance(cur, HarlequinPostgresCursor)
+    editable = cur.editable_columns()
+
+    # both columns come from a plain table, so both are editable
+    assert set(editable) == {0, 1}
+    id_table, id_col, id_is_pk = editable[0]
+    name_table, name_col, name_is_pk = editable[1]
+    assert "ed" in id_table and "id" in id_col
+    assert id_is_pk is True  # id is the primary key
+    assert name_is_pk is False  # name is not
+    assert "name" in name_col
+
+
+def test_editable_columns_excludes_computed_columns(
+    connection: HarlequinPostgresConnection,
+) -> None:
+    connection.execute("create table ed2 (id int primary key, qty int)")
+    # qty * 2 is derived, so it has no source table and is not editable;
+    # id still maps back to the base table.
+    cur = connection.execute("select id, qty * 2 as double_qty from ed2")
+    assert isinstance(cur, HarlequinPostgresCursor)
+    editable = cur.editable_columns()
+    assert 0 in editable
+    assert 1 not in editable
+
+
+def test_editable_columns_empty_without_source_table(
+    connection: HarlequinPostgresConnection,
+) -> None:
+    cur = connection.execute("select 1 as a, 'x' as b")
+    assert isinstance(cur, HarlequinPostgresCursor)
+    assert cur.editable_columns() == {}


### PR DESCRIPTION
Adds `HarlequinPostgresCursor.editable_columns()`: result-column index → `(qualified_table, quoted_column, is_primary_key)` for columns read straight from a table (`relkind in ('r', 'p')`, so views and computed columns are left out). It is driven by the source-table metadata libpq attaches to every result column (`ftable`/`ftablecol`), captured while the cursor is open, so it works across joins. Returns `{}` when nothing applies, and swallows metadata-query failures so it can never break fetching.

Harlequin's in-place cell editing (tconbeer/harlequin#987) calls it to build `update <table> set <column> = … where <pk> = …` and to key the row; adapters that don't implement it inherit an empty default there.

Split out of #56 so the two can land independently: #56 now carries only `foreign_key_columns()` (for tconbeer/harlequin#986). Both add the same source-column capture to the cursor's `__init__`; whichever merges second gets a one-hunk conflict.

### Tests
`test_editable_columns_marks_table_columns_and_pk`, `test_editable_columns_excludes_computed_columns`, `test_editable_columns_empty_without_source_table` — a plain table's columns are reported with the primary key flagged, a derived column is left out, and a result with no source table reports nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
