### PR TITLE
fix: return uuid values as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- `uuid` values are returned as text, so a result with a uuid column renders in Harlequin instead of failing with a `UnicodeDecodeError` while its column width is measured.
+
 ## [1.4.0] - 2026-08-29
 
 - This adapter now supports Harlequin's `--read-only` option and declares `IMPLEMENTS_READ_ONLY`. Read-only connections are enforced by the server, using `set session characteristics as transaction read only` ([#58](https://github.com/tconbeer/harlequin-postgres/issues/58)).

--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -37,7 +37,7 @@ from harlequin_postgres.catalog import (
 )
 from harlequin_postgres.cli_options import POSTGRES_OPTIONS
 from harlequin_postgres.completions import _get_completions
-from harlequin_postgres.loaders import register_inf_loaders
+from harlequin_postgres.loaders import register_inf_loaders, register_uuid_loaders
 
 _LIKE_ESCAPE = "\\"
 """What escapes a LIKE metacharacter in a term the caller typed."""
@@ -805,6 +805,7 @@ class HarlequinPostgresAdapter(HarlequinAdapter):
         # before creating the connection, register updated type adapters, so
         # all subsequent connections will use those adapters
         register_inf_loaders()
+        register_uuid_loaders()
         conn = HarlequinPostgresConnection(
             self.conn_str, options=self.options, read_only=self.read_only
         )

--- a/src/harlequin_postgres/loaders.py
+++ b/src/harlequin_postgres/loaders.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from datetime import date, datetime
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 import psycopg
+from psycopg.adapt import Loader
 from psycopg.errors import DataError
-
-# Subclass existing adapters so that the base case is handled normally.
+from psycopg.pq import Format
 from psycopg.types.datetime import (
     DateBinaryLoader,
     DateLoader,
@@ -15,6 +16,9 @@ from psycopg.types.datetime import (
     TimestamptzBinaryLoader,
     TimestamptzLoader,
 )
+
+# Subclass existing adapters so that the base case is handled normally.
+from psycopg.types.string import TextLoader
 
 if TYPE_CHECKING:
     from psycopg.adapt import Buffer, Loader
@@ -103,4 +107,29 @@ def register_inf_loaders() -> None:
     the updated loaders (that allow infinity date/timestamps)
     """
     for type_name, loader in INF_LOADERS:
+        psycopg.adapters.register_loader(type_name, loader)
+
+
+class UUIDTextBinaryLoader(Loader):
+    """Loads a binary-format uuid as its text form, like the text-format loader."""
+
+    format = Format.BINARY
+
+    def load(self, data: "Buffer") -> str:
+        return str(UUID(bytes=bytes(data)))
+
+
+UUID_LOADERS: list[tuple[str, type[Loader]]] = [
+    ("uuid", TextLoader),
+    ("uuid", UUIDTextBinaryLoader),
+]
+
+
+def register_uuid_loaders() -> None:
+    """
+    Register loaders that return uuid values as text. A uuid.UUID becomes an
+    Arrow extension type whose raw bytes textual-fastdatatable cannot measure,
+    so a result with a uuid column would fail to render.
+    """
+    for type_name, loader in UUID_LOADERS:
         psycopg.adapters.register_loader(type_name, loader)

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -13,6 +13,7 @@ from textual_fastdatatable.backend import create_backend
 from harlequin_postgres.adapter import (
     HarlequinPostgresAdapter,
     HarlequinPostgresConnection,
+    HarlequinPostgresCursor,
 )
 
 if sys.version_info < (3, 10):
@@ -294,3 +295,12 @@ def test_read_only_enforced_in_autocommit_session(
     assert read_only_connection._main_conn.autocommit is True
     with pytest.raises(HarlequinQueryError):
         read_only_connection.execute("insert into foo values (2)")
+
+
+def test_uuid_values_are_text(connection: HarlequinPostgresConnection) -> None:
+    cur = connection.execute("select '0e8f4e9a-8d3b-4c8a-9f1e-1d2c3b4a5f60'::uuid as u")
+    assert isinstance(cur, HarlequinPostgresCursor)
+    backend = create_backend(cur.fetchall())
+    assert backend.get_cell_at(0, 0) == "0e8f4e9a-8d3b-4c8a-9f1e-1d2c3b4a5f60"
+    # the width measurement that used to choke on the uuid's raw bytes
+    assert backend.column_content_widths[0] == 36


### PR DESCRIPTION
Any result with a `uuid` column fails to render in Harlequin 2.12 with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0x.. in position 0`.

**Why:** psycopg loads `uuid` as `uuid.UUID`; pyarrow (≥18) infers a column of those as the `arrow.uuid` extension type, whose storage is 16 raw bytes. textual-fastdatatable's `ArrowBackend._measure` then does `arr.cast(pa.string(), safe=False)` — which succeeds by reinterpreting the storage bytes — and its width UDF decodes them as UTF-8.

**Fix:** register text-format and binary-format loaders that return the uuid's text, the form the DuckDB adapter already produces (`register_uuid_loaders()`, next to `register_inf_loaders()`). `_sql_literal`-style consumers keep working: a quoted text literal compares fine against a `uuid` column.

The underlying measurement bug arguably belongs in textual-fastdatatable (skip the cast for extension types, or use `str()` on them); happy to open that too — this adapter-side change is the one that unblocks users today.

### Tests
`test_uuid_values_are_text`: a uuid cell comes back as its 36-char text and the column measures as 36 wide, which is the call that used to raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
