### PR TITLE
fix: return pooled connections outside of a transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixes noisy `rolling back returned connection:` warnings from `psycopg_pool`, one per catalog query, by returning pooled connections outside of a transaction. Catalog and completion queries now borrow their connection with `pool.connection()`, which also returns the connection to the pool if the query raises ([#61](https://github.com/tconbeer/harlequin-postgres/issues/61)).
+
 ## [1.4.0] - 2026-08-29
 
 - This adapter now supports Harlequin's `--read-only` option and declares `IMPLEMENTS_READ_ONLY`. Read-only connections are enforced by the server, using `set session characteristics as transaction read only` ([#58](https://github.com/tconbeer/harlequin-postgres/issues/58)).

--- a/src/harlequin_postgres/adapter.py
+++ b/src/harlequin_postgres/adapter.py
@@ -383,9 +383,8 @@ class HarlequinPostgresConnection(HarlequinConnection):
     ) -> list[CatalogSearchResult]:
         pattern = _contains_pattern(term)
         parameters = [pattern] * len(_SEARCH_BRANCHES[kind])
-        conn: Connection = self.pool.getconn()
         try:
-            with conn.cursor() as cur:
+            with self.pool.connection() as conn, conn.cursor() as cur:
                 cur.execute(_SEARCH_SQL[kind], parameters)
                 found: list[
                     tuple[
@@ -401,8 +400,6 @@ class HarlequinPostgresConnection(HarlequinConnection):
             raise HarlequinQueryError(
                 msg=str(e), title="Postgres raised an error searching the catalog:"
             ) from e
-        finally:
-            self.pool.putconn(conn)
 
         databases: dict[str, DatabaseCatalogItem] = {}
         schemas: dict[tuple[str, str], SchemaCatalogItem] = {}
@@ -474,10 +471,8 @@ class HarlequinPostgresConnection(HarlequinConnection):
         )
 
     def get_completions(self) -> list[HarlequinCompletion]:
-        conn: Connection = self.pool.getconn()
-        completions = _get_completions(conn)
-        self.pool.putconn(conn)
-        return completions
+        with self.pool.connection() as conn:
+            return _get_completions(conn)
 
     def close(self) -> None:
         self.pool.putconn(self._main_conn)
@@ -504,8 +499,7 @@ class HarlequinPostgresConnection(HarlequinConnection):
             conn.autocommit = False
 
     def _get_databases(self) -> list[tuple[str]]:
-        conn: Connection = self.pool.getconn()
-        with conn.cursor() as cur:
+        with self.pool.connection() as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select datname
@@ -517,12 +511,10 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 ;"""
             )
             results: list[tuple[str]] = cur.fetchall()
-        self.pool.putconn(conn)
         return results
 
     def _get_schemas(self, dbname: str) -> list[tuple[str]]:
-        conn: Connection = self.pool.getconn()
-        with conn.cursor() as cur:
+        with self.pool.connection() as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select schema_name
@@ -536,12 +528,10 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 (dbname,),
             )
             results: list[tuple[str]] = cur.fetchall()
-        self.pool.putconn(conn)
         return results
 
     def _get_relations(self, dbname: str, schema: str) -> list[tuple[str, str]]:
-        conn: Connection = self.pool.getconn()
-        with conn.cursor() as cur:
+        with self.pool.connection() as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select table_name, table_type
@@ -554,13 +544,11 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 (dbname, schema),
             )
             results: list[tuple[str, str]] = cur.fetchall()
-        self.pool.putconn(conn)
         return results
 
     # only works for the currently-connected db
     def _get_mvs(self, schema: str) -> list[tuple[str]]:
-        conn: Connection = self.pool.getconn()
-        with conn.cursor() as cur:
+        with self.pool.connection() as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select matviewname
@@ -572,14 +560,12 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 (schema,),
             )
             results: list[tuple[str]] = cur.fetchall()
-        self.pool.putconn(conn)
         return results
 
     def _get_columns(
         self, dbname: str, schema: str, relation: str
     ) -> list[tuple[str, str]]:
-        conn: Connection = self.pool.getconn()
-        with conn.cursor() as cur:
+        with self.pool.connection() as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select column_name, data_type
@@ -593,12 +579,10 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 (dbname, schema, relation),
             )
             results: list[tuple[str, str]] = cur.fetchall()
-        self.pool.putconn(conn)
         return results
 
     def _get_mv_cols(self, schema: str, mv: str) -> list[tuple[str, str]]:
-        conn: Connection = self.pool.getconn()
-        with conn.cursor() as cur:
+        with self.pool.connection() as conn, conn.cursor() as cur:
             cur.execute(
                 """
                 select 
@@ -617,7 +601,6 @@ class HarlequinPostgresConnection(HarlequinConnection):
                 (schema, mv),
             )
             results: list[tuple[str, str]] = cur.fetchall()
-        self.pool.putconn(conn)
         return results
 
     @staticmethod

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
+import logging
 import sys
 from datetime import date, datetime
 
 import psycopg
 import pytest
 from harlequin.adapter import HarlequinAdapter, HarlequinConnection, HarlequinCursor
-from harlequin.catalog import Catalog, CatalogItem
+from harlequin.catalog import Catalog, CatalogItem, InteractiveCatalogItem
 from harlequin.exception import HarlequinConnectionError, HarlequinQueryError
+from psycopg.pq import TransactionStatus
 from textual_fastdatatable.backend import create_backend
 
+from harlequin_postgres import adapter as adapter_module
 from harlequin_postgres.adapter import (
     HarlequinPostgresAdapter,
     HarlequinPostgresConnection,
@@ -166,6 +169,67 @@ def test_inf_timestamps(connection: HarlequinPostgresConnection) -> None:
             datetime.min,
         )
     ]
+
+
+def test_pooled_queries_return_idle_connections(
+    connection: HarlequinPostgresConnection,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """
+    Pooled connections are not autocommit, so a bare select leaves them INTRANS.
+    psycopg_pool logs a warning and rolls back for every connection returned that
+    way, so every helper that borrows one has to end its transaction first.
+    """
+    connection.execute("create schema one")
+    connection.execute("create table one.foo as select 1 as a")
+
+    with caplog.at_level(logging.WARNING, logger="psycopg.pool"):
+        catalog = connection.get_catalog()
+        [db_item] = [item for item in catalog.items if item.label == "test"]
+        assert isinstance(db_item, InteractiveCatalogItem)
+        [schema_item] = [
+            item for item in db_item.fetch_children() if item.label == "one"
+        ]
+        assert isinstance(schema_item, InteractiveCatalogItem)
+        [relation_item] = [
+            item for item in schema_item.fetch_children() if item.label == "foo"
+        ]
+        assert isinstance(relation_item, InteractiveCatalogItem)
+        relation_item.fetch_children()
+        connection.search_catalog("foo")
+        connection.get_completions()
+
+    assert [
+        record.getMessage()
+        for record in caplog.records
+        if record.name.startswith("psycopg")
+    ] == []
+
+    with connection.pool.connection() as conn:
+        assert conn.info.transaction_status == TransactionStatus.IDLE
+
+
+def test_failed_pooled_query_does_not_leak_connections(
+    connection: HarlequinPostgresConnection,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    A borrowed connection has to go back to the pool when the query raises, too;
+    otherwise a handful of failures would exhaust the pool.
+    """
+
+    def raise_error(conn: psycopg.Connection) -> None:
+        raise ValueError("boom")
+
+    monkeypatch.setattr(adapter_module, "_get_completions", raise_error)
+
+    for _ in range(connection.pool.max_size + 5):
+        with pytest.raises(ValueError):
+            connection.get_completions()
+
+    monkeypatch.undo()
+    # the pool still has connections to give out
+    assert connection.get_completions()
 
 
 def test_closed_conn_raises_right_error(


### PR DESCRIPTION
Closes #61, using option 1 from the issue.

## The change

Every helper that borrowed a pooled connection ran a `select` and handed the connection back while it was still `INTRANS`, so `psycopg_pool` logged a warning and rolled back for each one. All eight borrow sites now use the pool's context manager instead:

```python
with self.pool.connection() as conn, conn.cursor() as cur:
    ...
```

`ConnectionPool.connection()` wraps the connection in `with conn:`, which commits on a clean exit and rolls back on an exception, so the connection is `IDLE` when `putconn()` runs and `_reset_connection()` has nothing to warn about. (`Connection.__exit__` skips its `close()` for a connection that belongs to a pool, so the pool keeps its connections.)

Sites changed: `_get_databases()`, `_get_schemas()`, `_get_relations()`, `_get_mvs()`, `_get_columns()`, `_get_mv_cols()`, `search_catalog()`, and `get_completions()`. `_main_conn` and `close()` are untouched.

This also fixes the leak the issue mentions in passing: every helper except `search_catalog()` skipped its `putconn()` when the query raised, so a handful of failures permanently drained the pool.

## Behavior notes

- `search_catalog()` no longer needs its `try/finally`, but it kept its `except Error` — and `PoolTimeout`/`PoolClosed` subclass `psycopg.OperationalError`, so a checkout timeout there now surfaces as a `HarlequinQueryError` (an error toast) rather than propagating raw.
- Pooled connections now end their transaction with `COMMIT` instead of the pool's `ROLLBACK`. These are read-only introspection queries, so it is the same one round trip either way, and nothing is written.
- One warning path is left, and it is out of scope for this issue: in Manual transaction mode with an uncommitted transaction, `close()` returns `_main_conn` while it is `INTRANS`, so quitting logs a single `rolling back returned connection:`. The rollback is what should happen there; only the log line is noise.

## Tests

Two regression tests in `tests/test_adapter.py`, both verified to fail on `main` and pass here:

- `test_pooled_queries_return_idle_connections` — walks all four catalog levels, searches, and fetches completions inside `caplog`, asserting no `psycopg` warnings, then asserts a freshly borrowed connection is `IDLE`. On `main` it fails with 8 `rolling back returned connection:` records.
- `test_failed_pooled_query_does_not_leak_connections` — makes `_get_completions` raise `max_size + 5` times, then asserts the pool still hands out connections. On `main` it exhausts the pool and dies with `PoolTimeout`.

`make check` is green against a local Postgres 16: `ruff format`, `ruff check`, `mypy`, and 58 passing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xoney8tNjqK1Ex9QC5DCfW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xoney8tNjqK1Ex9QC5DCfW)_